### PR TITLE
add links to tla+ file: specification of the consensus algorithm in Tencent storage system PaxosStore

### DIFF
--- a/specifications/TecentPaxos/README.md
+++ b/specifications/TecentPaxos/README.md
@@ -1,0 +1,9 @@
+#### ﻿[Tencent-Paxos-TLA](https://github.com/Starydark/Tencent-Paxos-TLA)
+
+ - Specification's authors: Xingchen Yi, Hengfeng Wei
+ - Original paper: [Zheng, Jianjun, et al. PaxosStore: high-availability storage made practical in WeChat. Proceedings of the VLDB Endowment. 2017.](http://www.vldb.org/pvldb/vol10/p1730-lin.pdf)
+ - Extended modules: Integers, FiniteSets
+ - Computation models: crashes, lost/duplicated messages
+ - Some properties checked with TLC: Consistency
+ - <a href="https://github.com/Starydark/Tencent-Paxos-TLA">TLA<sup>+</sup> files</a>
+


### PR DESCRIPTION
PaxosStore is a storage system used in wechat. See [PaxosStore@VLDB2017](https://www.vldb.org/pvldb/vol10/p1730-lin.pdf) by Tencent.
We give the specification of the consensus algorithm in PaxosStore and model check the refinement mapping we establish.