### PR TITLE
Fixing None in Paxos

### DIFF
--- a/specifications/Paxos/Paxos.tla
+++ b/specifications/Paxos/Paxos.tla
@@ -15,7 +15,7 @@ ASSUME QuorumAssumption == /\ \A Q \in Quorum : Q \subseteq Acceptor
       
 Ballot ==  Nat
 
-None == CHOOSE v : v \notin Ballot
+None == CHOOSE v : v \notin Value
   (*************************************************************************)
   (* An unspecified value that is not a ballot number.                     *)
   (*************************************************************************)


### PR DESCRIPTION
I believe there is a typo in the line: `None == CHOOSE v : v \notin Ballot`. Theoretically, `CHOOSE v: v \notin Ballot` is allowed to return a value for `None` that belongs to `Values`, but is outside of `Ballot`. The value `None` is used together with values, not ballots. The undefined value for ballot is -1.