### PR TITLE
Fix liveness checking in ada-asyn-byz

### DIFF
--- a/specifications/aba-asyn-byz/aba_asyn_byz.tla
+++ b/specifications/aba-asyn-byz/aba_asyn_byz.tla
@@ -126,7 +126,7 @@ Spec == Init /\ [][Next]_vars
                                            \/ Decide(self))
                                            
 Spec0 == Init0 /\ [][Next]_vars 
-               /\ WF_vars(\E self \in Proc : \/ Receive(self)
+               /\ WF_vars(\E self \in Proc : \/ Receive(self, FALSE)
                                              \/ SendEcho(self)
                                              \/ SendReady(self)
                                              \/ Decide(self))                                           


### PR DESCRIPTION
There was a mistake in the fairness condition. It implicitly included the actions of Byzantine processes, which practically forces the Byzantine processes to cooperate with the correct processes.

To verify that there was a mistake, you can modify the threshold `guardR2` from `2 * T + 1` to `T + 1`. This change breaks the protocol and the model checking should fail, but it will pass with the original specification due to a too strong fairness condition.