### PR TITLE
Fix liveness checking in bcastByz

### DIFF
--- a/specifications/bcastByz/bcastByz.tla
+++ b/specifications/bcastByz/bcastByz.tla
@@ -83,12 +83,17 @@ InitNoBcast == pc \in [ Proc -> {"V0"} ] /\ Init
 
 (* A correct process can receive all ECHO messages sent by the other correct processes,
    i.e., a subset of sent, and all possible ECHO messages from the Byzantine processes,
-   i.e., a subset of ByzMsgs.
+   i.e., a subset of ByzMsgs. If includeByz is FALSE, the messages from the Byzantine
+   processes are not included.
  *)
-Receive(self) ==
-  \E newMessages \in SUBSET ( sent \cup ByzMsgs ) :
+Receive(self, includeByz) ==
+  \E newMessages \in SUBSET ( sent \cup (IF includeByz THEN ByzMsgs ELSE {}) ) :
     rcvd' = [ i \in Proc |-> IF i # self THEN rcvd[i] ELSE rcvd[self] \cup newMessages ]
-                             
+
+ReceiveFromCorrectSender(self) == Receive(self, FALSE)
+
+ReceiveFromAnySender(self) == Receive(self, TRUE)
+
 (* The first if-then expression in Figure 7 [1]: If process p received an INIT message and
    did not send <ECHO> before, then process p sends ECHO to all.
  *)
@@ -142,7 +147,7 @@ UponAcceptSentBefore(self) ==
 
 (* All possible process steps.*)                
 Step(self) == 
-  /\ Receive(self)
+  /\ ReceiveFromAnySender(self)
   /\ \/ UponV1(self)
      \/ UponNonFaulty(self)
      \/ UponAcceptNotSentBefore(self)
@@ -158,7 +163,7 @@ Next ==
    forever enabled, then this step must eventually occur.      
  *)
 Spec == Init /\ [][Next]_vars 
-             /\ WF_vars(\E self \in Corr: /\ Receive(self)
+             /\ WF_vars(\E self \in Corr: /\ ReceiveFromCorrectSender(self)
                                           /\ \/ UponV1(self)
                                              \/ UponNonFaulty(self)
                                              \/ UponAcceptNotSentBefore(self)
@@ -617,13 +622,13 @@ THEOREM FCConstraints_TypeOK_Next ==
                  PROVE FCConstraints' /\ TypeOK'
                  BY <2>1
       <3>1 Step(i) <=>            
-            \/ Receive(i) /\ UponV1(i)
-            \/ Receive(i) /\ UponNonFaulty(i) 
-            \/ Receive(i) /\ UponAcceptNotSentBefore(i)
-            \/ Receive(i) /\ UponAcceptSentBefore(i)            
-            \/ Receive(i) /\ UNCHANGED << pc, sent, Corr, Faulty >>
+            \/ ReceiveFromAnySender(i) /\ UponV1(i)
+            \/ ReceiveFromAnySender(i) /\ UponNonFaulty(i) 
+            \/ ReceiveFromAnySender(i) /\ UponAcceptNotSentBefore(i)
+            \/ ReceiveFromAnySender(i) /\ UponAcceptSentBefore(i)            
+            \/ ReceiveFromAnySender(i) /\ UNCHANGED << pc, sent, Corr, Faulty >>
         BY DEF Step 
-      <3>2 CASE Receive(i) /\ UponV1(i)
+      <3>2 CASE ReceiveFromAnySender(i) /\ UponV1(i)
         <4>1 FCConstraints'
           BY <3>2 DEF Receive, UponV1, FCConstraints, ByzMsgs
         <4>2 TypeOK'
@@ -655,7 +660,7 @@ THEOREM FCConstraints_TypeOK_Next ==
             BY <1>2, <3>2, <4>1, <5>1, <5>5, <5>6 DEF TypeOK, FCConstraints
         <4> QED
           BY <4>1, <4>2       
-      <3>3 CASE Receive(i) /\ UponNonFaulty(i)
+      <3>3 CASE ReceiveFromAnySender(i) /\ UponNonFaulty(i)
         <4>1 FCConstraints'
           BY <3>3 DEF Receive, UponNonFaulty, FCConstraints, ByzMsgs
         <4>2 TypeOK'
@@ -687,7 +692,7 @@ THEOREM FCConstraints_TypeOK_Next ==
             BY <1>2, <3>3, <4>1, <5>1, <5>5, <5>6 DEF TypeOK, FCConstraints
         <4> QED
           BY <4>1, <4>2
-      <3>4 CASE Receive(i) /\ UponAcceptNotSentBefore(i)
+      <3>4 CASE ReceiveFromAnySender(i) /\ UponAcceptNotSentBefore(i)
         <4>1 FCConstraints'
           BY <3>4 DEF Receive, UponAcceptNotSentBefore, FCConstraints, ByzMsgs
         <4>2 TypeOK'
@@ -719,7 +724,7 @@ THEOREM FCConstraints_TypeOK_Next ==
             BY <1>2, <3>4, <4>1, <5>1, <5>5, <5>6 DEF TypeOK, FCConstraints
         <4> QED
           BY <4>1, <4>2 
-      <3>5 CASE Receive(i) /\ UponAcceptSentBefore(i)
+      <3>5 CASE ReceiveFromAnySender(i) /\ UponAcceptSentBefore(i)
         <4>1 FCConstraints'
           BY <3>5 DEF Receive, UponAcceptSentBefore, FCConstraints, ByzMsgs
         <4>2 TypeOK'
@@ -751,7 +756,7 @@ THEOREM FCConstraints_TypeOK_Next ==
             BY <1>2, <3>5, <4>1, <5>1, <5>5, <5>6 DEF TypeOK, FCConstraints
         <4> QED
           BY <4>1, <4>2  
-      <3>6 CASE Receive(i) /\ UNCHANGED << pc, sent, Corr, Faulty >>
+      <3>6 CASE ReceiveFromAnySender(i) /\ UNCHANGED << pc, sent, Corr, Faulty >>
         <4>1 FCConstraints'
           BY <3>6 DEF FCConstraints, ByzMsgs
         <4>2 TypeOK'
@@ -865,18 +870,18 @@ THEOREM Unforg_Step2 == IndInv_Unforg_NoBcast /\ [Next]_vars => IndInv_Unforg_No
         BY FCConstraints_TypeOK_Next DEF IndInv_Unforg_NoBcast    
       <3>2 sent' = {} /\ pc' = [ j \in Proc |-> "V0" ]
         <4>1 Step(i) <=>
-                \/ Receive(i) /\ UponV1(i)
-                \/ Receive(i) /\ UponNonFaulty(i) 
-                \/ Receive(i) /\ UponAcceptNotSentBefore(i)
-                \/ Receive(i) /\ UponAcceptSentBefore(i)            
-                \/ Receive(i) /\ UNCHANGED << pc, sent, Corr, Faulty >>
+                \/ ReceiveFromAnySender(i) /\ UponV1(i)
+                \/ ReceiveFromAnySender(i) /\ UponNonFaulty(i) 
+                \/ ReceiveFromAnySender(i) /\ UponAcceptNotSentBefore(i)
+                \/ ReceiveFromAnySender(i) /\ UponAcceptSentBefore(i)            
+                \/ ReceiveFromAnySender(i) /\ UNCHANGED << pc, sent, Corr, Faulty >>
           BY DEF Step
-        <4>2 IndInv_Unforg_NoBcast/\ Receive(i) => Cardinality(rcvd'[i]) <= T /\ Cardinality(rcvd'[i]) \in Nat
+        <4>2 IndInv_Unforg_NoBcast/\ ReceiveFromAnySender(i) => Cardinality(rcvd'[i]) <= T /\ Cardinality(rcvd'[i]) \in Nat
           <5> SUFFICES ASSUME TypeOK,
                               FCConstraints,
                               sent = {},
                               pc = [ j \in Proc |->  "V0" ],
-                              Receive(i)
+                              ReceiveFromAnySender(i)
                        PROVE  Cardinality(rcvd'[i]) <= T /\ Cardinality(rcvd'[i]) \in Nat
               BY DEF IndInv_Unforg_NoBcast
           <5>1 sent = {}
@@ -916,11 +921,11 @@ THEOREM Unforg_Step2 == IndInv_Unforg_NoBcast /\ [Next]_vars => IndInv_Unforg_No
             BY <5>16, FS_CardinalityType
           <5> QED
             BY <5>17, <5>13, <5>11, <5>12, NTFRel
-        <4>3 CASE Receive(i) /\ UNCHANGED << pc, sent, Corr, Faulty >>  
+        <4>3 CASE ReceiveFromAnySender(i) /\ UNCHANGED << pc, sent, Corr, Faulty >>  
           BY <4>3 DEF IndInv_Unforg_NoBcast      
-        <4>4 IndInv_Unforg_NoBcast /\ Receive(i) => ~UponV1(i) 
+        <4>4 IndInv_Unforg_NoBcast /\ ReceiveFromAnySender(i) => ~UponV1(i) 
           <5> SUFFICES ASSUME IndInv_Unforg_NoBcast,
-                              Receive(i)
+                              ReceiveFromAnySender(i)
                        PROVE ~UponV1(i)                   
                        OBVIOUS
           <5>1 ~UponV1(i) =
@@ -938,9 +943,9 @@ THEOREM Unforg_Step2 == IndInv_Unforg_NoBcast /\ [Next]_vars => IndInv_Unforg_No
               BY <6>2
           <5> QED
             BY <5>1, <5>2          
-        <4>5 IndInv_Unforg_NoBcast /\ Receive(i) => ~UponNonFaulty(i) 
+        <4>5 IndInv_Unforg_NoBcast /\ ReceiveFromAnySender(i) => ~UponNonFaulty(i) 
           <5> SUFFICES ASSUME IndInv_Unforg_NoBcast,
-                              Receive(i)
+                              ReceiveFromAnySender(i)
                        PROVE ~UponNonFaulty(i)                   
                        OBVIOUS
           <5>1 ~UponNonFaulty(i) =
@@ -962,9 +967,9 @@ THEOREM Unforg_Step2 == IndInv_Unforg_NoBcast /\ [Next]_vars => IndInv_Unforg_No
               BY <5>1, NTFRel, <6>3 DEF UponNonFaulty
           <5> QED
             BY <4>2, <5>2
-        <4>6 IndInv_Unforg_NoBcast /\ Receive(i) => ~UponAcceptNotSentBefore(i) 
+        <4>6 IndInv_Unforg_NoBcast /\ ReceiveFromAnySender(i) => ~UponAcceptNotSentBefore(i) 
           <5> SUFFICES ASSUME IndInv_Unforg_NoBcast,
-                              Receive(i)
+                              ReceiveFromAnySender(i)
                        PROVE ~UponAcceptNotSentBefore(i)                   
                        OBVIOUS
           <5>1 ~UponAcceptNotSentBefore(i) =
@@ -987,9 +992,9 @@ THEOREM Unforg_Step2 == IndInv_Unforg_NoBcast /\ [Next]_vars => IndInv_Unforg_No
               BY <5>1, NTFRel, <6>4 DEF UponAcceptNotSentBefore
           <5> QED
             BY <4>2, <5>2
-        <4>7 IndInv_Unforg_NoBcast /\ Receive(i) => ~UponAcceptSentBefore(i) 
+        <4>7 IndInv_Unforg_NoBcast /\ ReceiveFromAnySender(i) => ~UponAcceptSentBefore(i) 
           <5> SUFFICES ASSUME IndInv_Unforg_NoBcast,
-                              Receive(i)
+                              ReceiveFromAnySender(i)
                        PROVE ~UponAcceptSentBefore(i)                   
                        OBVIOUS
           <5>1 ~UponAcceptSentBefore(i) =


### PR DESCRIPTION
Similar to #39

There was a mistake in the fairness condition. It implicitly included the actions of Byzantine processes, which practically forces the Byzantine processes to cooperate with the correct processes.

To verify that there was a mistake, you can change the threshold in `UponAcceptNotSentBefore` and `UponAcceptSentBefore` from `N - T` to `N - 2*T`. This change breaks the protocol and the model checking should fail, but it will pass with the original specification due to a too strong fairness condition.