### PR TITLE
Rename read and write predicates in ReadersWriters specification

### DIFF
--- a/specifications/ReadersWriters/ReadersWriters.tla
+++ b/specifications/ReadersWriters/ReadersWriters.tla
@@ -19,12 +19,13 @@ Actors == 1..NumActors
 
 ToSet(s) == { s[i] : i \in DOMAIN s }
 
-read(s)  == s[1] = "read"
-write(s) == s[1] = "write"
+\* predicates to check the type of a process: read or write
+IsRead(s)  == s[1] = "read"
+IsWrite(s) == s[1] = "write"
 
-WaitingToRead  == { p[2] : p \in ToSet(SelectSeq(waiting, read)) }
+WaitingToRead  == { p[2] : p \in ToSet(SelectSeq(waiting, IsRead)) }
 
-WaitingToWrite == { p[2] : p \in ToSet(SelectSeq(waiting, write)) }
+WaitingToWrite == { p[2] : p \in ToSet(SelectSeq(waiting, IsWrite)) }
 
 ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Use "IsRead/IsWrite" instead of "read/write" as names of the predicates
checking the type of processes.

Using "Is*" naming pattern for predicates in other specifications seems
to be the norm. It also makes ReadersWriters specification easier to
understand.