### PR TITLE
Co-locate steps to remove a process from waiting queue in ReadersWriters example

### DIFF
--- a/specifications/ReadersWriters/ReadersWriters.tla
+++ b/specifications/ReadersWriters/ReadersWriters.tla
@@ -23,7 +23,6 @@ read(s)  == s[1] = "read"
 write(s) == s[1] = "write"
 
 WaitingToRead  == { p[2] : p \in ToSet(SelectSeq(waiting, read)) }
-
 WaitingToWrite == { p[2] : p \in ToSet(SelectSeq(waiting, write)) }
 
 ---------------------------------------------------------------------------
@@ -44,13 +43,11 @@ TryWrite(actor) ==
 
 Read(actor) ==
     /\ readers' = readers \union {actor}
-    /\ waiting' = Tail(waiting)
     /\ UNCHANGED writers
 
 Write(actor) ==
     /\ readers = {}
     /\ writers' = writers \union {actor}
-    /\ waiting' = Tail(waiting)
     /\ UNCHANGED readers
 
 ReadOrWrite ==
@@ -60,6 +57,7 @@ ReadOrWrite ==
            actor == pair[2]
        IN CASE pair[1] = "read" -> Read(actor)
             [] pair[1] = "write" -> Write(actor)
+    /\ waiting' = Tail(waiting)
 
 StopActivity(actor) ==
     IF actor \in readers


### PR DESCRIPTION
The steps to remove a process from the waiting queue are

- get the head of the queue
- remove the head by keeping the tail of the queue

These two steps are spread across Read, Write, and ReadOrWrite
operators. This makes the specification harder to understand.

Improve the readability of the specification by keeping all the steps
within ReadOrWrite operator.