### PR TITLE
add Petri Nets from elh/petri-tlaplus

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Do you have your own case study that you like to share with the community? Send 
 | 87  | MET for CRDT-Redis         | <a href="https://github.com/elem-azar-unis/CRDT-Redis/tree/master/MET/TLA">Model-check the CRDT designs, then generate test cases to test CRDT implementations</a>  | Yuqi Zhang  |             |                                                   &#10004;                                                    | Integers, Sequences, FiniteSets, TLC              | &#10004; | |
 | 88  | Parallel increment    | <a href="https://github.com/Cjen1/tla_increment">Parallel threads incrementing a shared variable. Demonstrates invariants, liveness, fairness and symmetry</a>  | Chris Jensen |             |                                                   &#10004;                                                    | Integers, FiniteSets, TLC              | | |
 | 89 | The Streamlet consensus algorithm | <a href="https://www.losa.fr/blog/streamlet-in-tla+">Specification and model-checking of both safety and liveness properties of Streamlet with TLC</a> | Giuliano Losa | | &#10004; | Sequences, Integers, FiniteSets | &#10004; | |
+| 90 | Petri Nets | <a href="https://github.com/elh/petri-tlaplus">Instantiable Petri Nets with liveness properties</a> | Eugene Huang | | &#10004; | Integers, Sequences, FiniteSets, TLC | |
 
 ## License
 


### PR DESCRIPTION
Modeling [Petri nets](https://en.wikipedia.org/wiki/Petri_net) in TLA+. Specific configurations can be instantiated and checked if they are valid for conventional Petri net safety and liveness properties.

The repo: https://github.com/elh/petri-tlaplus

Been really enjoying learning TLA+ and would love to contribute!