### PR TITLE
Fix invalid utf8 in SimpleRegular.tla and invalid syntax in Specifying Systems modules

### DIFF
--- a/specifications/SpecifyingSystems/Standard/Naturals.tla
+++ b/specifications/SpecifyingSystems/Standard/Naturals.tla
@@ -3,11 +3,11 @@ LOCAL R == INSTANCE ProtoReals
 
 Nat == R!Nat
 
-a + b == a R!+ b
-a - b == a R!- b
-a * b == a R!* b
-a ^ b == a R!^ b
-a \leq b == a R!\leq b
+a + b == R!+(a, b)
+a - b == R!-(a, b)
+a * b == R!*(a, b)
+a ^ b == R!^(a, b)
+a \leq b == R!\leq(a, b)
 a \geq b == b \leq a
 a < b == (a \leq b) /\ (a # b)
 a > b == b < a

--- a/specifications/SpecifyingSystems/Standard/Reals.tla
+++ b/specifications/SpecifyingSystems/Standard/Reals.tla
@@ -3,6 +3,6 @@ EXTENDS Integers
 LOCAL R == INSTANCE ProtoReals
 
 Real  ==  R!Real
-a / b == a R!/(a, b)
+a / b == R!/(a, b)
 Infinity == R!Infinity
 =============================================================================

--- a/specifications/SpecifyingSystems/Standard/Reals.tla
+++ b/specifications/SpecifyingSystems/Standard/Reals.tla
@@ -3,6 +3,6 @@ EXTENDS Integers
 LOCAL R == INSTANCE ProtoReals
 
 Real  ==  R!Real
-a / b == a R!/ b
+a / b == a R!/(a, b)
 Infinity == R!Infinity
 =============================================================================

--- a/specifications/TeachingConcurrency/SimpleRegular.tla
+++ b/specifications/TeachingConcurrency/SimpleRegular.tla
@@ -48,7 +48,7 @@
 (* The problem of generalizing the algorithm of module Simple to use       *)
 (* regular registers was proposed by Yuri Abraham in                       *)
 (*                                                                         *)
-(*    On Lamport’s “Teaching Concurrency”                                  *)
+(*    On Lamport's "Teaching Concurrency"                                  *)
 (*    Bulletin of EATS (European Association for Theoretical Computer      *)
 (*      Science) No. 127, February 2019                                    *)
 (*    http://bulletin.eatcs.org/index.php/beatcs/article/view/569          *)

--- a/specifications/diskpaxos/Synod.tla
+++ b/specifications/diskpaxos/Synod.tla
@@ -16,9 +16,9 @@ VARIABLES input, output
 VARIABLES allInput, chosen
 
 IInit == /\ input \in [Proc -> Inputs]
-        /\ output = [p \in Proc |-> NotAnInput]
-        /\ chosen = NotAnInput
-        /\ allInput = {input[p] : p \in Proc}
+         /\ output = [p \in Proc |-> NotAnInput]
+         /\ chosen = NotAnInput
+         /\ allInput = {input[p] : p \in Proc}
 
 IChoose(p) ==
   /\ output[p] = NotAnInput


### PR DESCRIPTION
The invalid utf8 causes file.read functions to panic in several libraries. The invalid utf8 concerns the line containing `On Lamport's "Teaching Concurrency"`; the rest of the changes to that file were automatically added by github itself (normalizing line endings, I think).

I also fixed invalid syntax in the Reals.tla and Naturals.tla standard modules from Specifying Systems. These used archaic infix operator syntax like `a R!+ b` which are no longer valid; this was replaced by nonfix syntax `R!+(a, b)`. While this may mean they no longer reflect the specs as they were published in Specifying Systems, I figure an example repo should only contains specs that have correct syntax.

I also fixed an unintentionally-misaligned conjunction list in Synod.tla.