### PR TITLE
Parameterize parse/check python scripts for ease of use from other repos

### DIFF
--- a/.github/scripts/check_small_models.py
+++ b/.github/scripts/check_small_models.py
@@ -4,7 +4,9 @@ models should finish executing in less than ten seconds on the GitHub CI
 machines.
 """
 
+from argparse import ArgumentParser
 import logging
+from os.path import dirname, join, normpath
 from timeit import default_timer as timer
 import tla_utils
 
@@ -15,14 +17,33 @@ tlc_result = {
     13  : 'liveness failure'
 }
 
+parser = ArgumentParser(description='Checks all small TLA+ models in the tlaplus/examples repo using TLC.')
+parser.add_argument('--tools_jar_path', help='Path to the tla2tools.jar file', required=True)
+parser.add_argument('--tlapm_lib_path', help='Path to the TLA+ proof manager module directory; .tla files should be in this directory', required=True)
+parser.add_argument('--community_modules_jar_path', help='Path to the CommunityModules-deps.jar file', required=True)
+parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
+args = parser.parse_args()
+
+logging.basicConfig(level=logging.INFO)
+
+tools_jar_path = normpath(args.tools_jar_path)
+tlapm_lib_path = normpath(args.tlapm_lib_path)
+community_jar_path = normpath(args.community_modules_jar_path)
+manifest_path = normpath(args.manifest_path)
+examples_root_path = dirname(manifest_path)
+
 def check_model(module_path, model, expected_runtime):
-    model_path = model['path']
+    module_path = normpath(join(examples_root_path, module_path))
+    model_path = normpath(join(examples_root_path, model['path']))
     logging.info(model_path)
     expected_result = model['result']
     start_time = timer()
     tlc, hit_timeout = tla_utils.check_model(
+        tools_jar_path,
         module_path,
         model_path,
+        tlapm_lib_path,
+        community_jar_path,
         model['mode'],
         model['config'],
         60
@@ -39,11 +60,8 @@ def check_model(module_path, model, expected_runtime):
         return False
     return True
 
-logging.basicConfig(level=logging.INFO)
-
-manifest = tla_utils.load_manifest()
-
 # Ensure longest-running modules go first
+manifest = tla_utils.load_json(manifest_path)
 small_models = sorted(
     [
         (module['path'], model, tla_utils.parse_timespan(model['runtime']))

--- a/.github/scripts/parse_modules.py
+++ b/.github/scripts/parse_modules.py
@@ -2,15 +2,25 @@
 Parse all modules in the manifest with SANY.
 """
 
+from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor
 import logging
 from os import cpu_count
-from os.path import dirname, normpath, pathsep
+from os.path import dirname, normpath, pathsep, join
 import subprocess
 import tla_utils
 
-tlaps_modules = normpath('tlapm/library')
-community_modules = normpath('CommunityModules/modules')
+parser = ArgumentParser(description='Parses all TLA+ modules in the tlaplus/examples repo using SANY.')
+parser.add_argument('--tools_jar_path', help='Path to the tla2tools.jar file', required=True)
+parser.add_argument('--tlapm_lib_path', help='Path to the TLA+ proof manager module directory; .tla files should be in this directory', required=True)
+parser.add_argument('--community_modules_path', help='Path to the TLA+ community module directory; .tla files should be in this directory', required=True)
+parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
+args = parser.parse_args()
+
+tools_jar_path = normpath(args.tools_jar_path)
+tlaps_modules = normpath(args.tlapm_lib_path)
+community_modules = normpath(args.community_modules_path)
+manifest_path = normpath(args.manifest_path)
 logging.basicConfig(level=logging.INFO)
 
 def parse_module(path):
@@ -18,7 +28,7 @@ def parse_module(path):
     Parse the given module using SANY.
     """
     logging.info(path)
-    search_paths = pathsep.join(['tla2tools.jar', dirname(path), tlaps_modules, community_modules])
+    search_paths = pathsep.join([tools_jar_path, dirname(path), tlaps_modules, community_modules])
     sany = subprocess.run([
         'java',
         '-cp', search_paths,
@@ -31,7 +41,7 @@ def parse_module(path):
         return False
     return True
 
-manifest = tla_utils.load_manifest()
+manifest = tla_utils.load_json(manifest_path)
 
 # Skip these specs and modules as they do not currently parse
 skip_specs = [
@@ -42,7 +52,7 @@ skip_modules = []
 
 # List of all modules to parse and whether they should use TLAPS imports
 modules = [
-    normpath(module['path'])
+    normpath(join(dirname(manifest_path), normpath(module['path'])))
     for spec in manifest['specifications'] if spec['path'] not in skip_specs
     for module in spec['modules'] if module['path'] not in skip_modules
 ]

--- a/.github/scripts/smoke_test_large_models.py
+++ b/.github/scripts/smoke_test_large_models.py
@@ -4,16 +4,35 @@ entails running them for five seconds to ensure they can actually start
 and work with the spec they're supposed to be modeling.
 """
 
+from argparse import ArgumentParser
 import logging
 import os
+from os.path import dirname, join, normpath
 import tla_utils
 
+parser = ArgumentParser(description='Smoke-tests all larger TLA+ models in the tlaplus/examples repo using TLC.')
+parser.add_argument('--tools_jar_path', help='Path to the tla2tools.jar file', required=True)
+parser.add_argument('--tlapm_lib_path', help='Path to the TLA+ proof manager module directory; .tla files should be in this directory', required=True)
+parser.add_argument('--community_modules_jar_path', help='Path to the CommunityModules-deps.jar file', required=True)
+parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
+args = parser.parse_args()
+
+tools_jar_path = normpath(args.tools_jar_path)
+tlapm_lib_path = normpath(args.tlapm_lib_path)
+community_jar_path = normpath(args.community_modules_jar_path)
+manifest_path = normpath(args.manifest_path)
+examples_root_path = dirname(manifest_path)
+
 def check_model(module_path, model):
-    model_path = model['path']
+    module_path = normpath(join(examples_root_path, module_path))
+    model_path = normpath(join(examples_root_path, model['path']))
     logging.info(model_path)
     tlc, hit_timeout = tla_utils.check_model(
+        tools_jar_path,
         module_path,
         model_path,
+        tlapm_lib_path,
+        community_jar_path,
         model['mode'],
         model['config'],
         5
@@ -28,7 +47,7 @@ def check_model(module_path, model):
 
 logging.basicConfig(level=logging.INFO)
 
-manifest = tla_utils.load_manifest()
+manifest = tla_utils.load_json(manifest_path)
 
 skip_models = [
     # SimKnuthYao requires certain number of states to have been generated

--- a/.github/scripts/tla_utils.py
+++ b/.github/scripts/tla_utils.py
@@ -78,13 +78,15 @@ def get_config(config):
     """
     return ['-deadlock'] if 'ignore deadlock' in config else []
 
-def check_model(module_path, model_path, mode, config, timeout):
+def check_model(tools_jar_path, module_path, model_path, tlapm_lib_path, community_jar_path, mode, config, timeout):
     """
     Model-checks the given model against the given module.
     """
+    tools_jar_path = normpath(tools_jar_path)
     module_path = normpath(module_path)
     model_path = normpath(model_path)
-    tlaps_modules = normpath('tlapm/library')
+    tlapm_lib_path = normpath(tlapm_lib_path)
+    community_jar_path = normpath(community_jar_path)
     try:
         tlc = subprocess.run(
             [
@@ -92,7 +94,7 @@ def check_model(module_path, model_path, mode, config, timeout):
                 '-Dtlc2.TLC.ide=Github',
                 '-Dutil.ExecutionStatisticsCollector.id=abcdef60f238424fa70d124d0c77ffff',
                 '-XX:+UseParallelGC',
-                '-cp', pathsep.join(['tla2tools.jar', tlaps_modules]),
+                '-cp', pathsep.join([tools_jar_path, community_jar_path, tlapm_lib_path]),
                 'tlc2.TLC',
                 module_path,
                 '-config', model_path,

--- a/.github/scripts/tla_utils.py
+++ b/.github/scripts/tla_utils.py
@@ -36,13 +36,13 @@ def load_json(path):
 
 def load_manifest():
     """
-    Loads the manifest.json file.
+    Loads the manifest.json file at the default path.
     """
     return load_json('manifest.json')
 
 def load_schema():
     """
-    Loads the schema for the manifest.json file.
+    Loads the schema for the manifest.json file at the default path.
     """
     return load_json('manifest-schema.json')
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - master
+  repository_dispatch:
+    types: [tlaplus-dispatch]
 
 jobs:
   validate:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,10 +41,7 @@ jobs:
         if: matrix.os == 'windows-latest'
       - name: Install python packages
         shell: bash
-        run: |
-          python -m venv .
-          source ./bin/activate
-          pip install -r $SCRIPT_DIR/requirements.txt
+        run: pip install -r $SCRIPT_DIR/requirements.txt
       - name: Download TLA⁺ dependencies
         run: |
           # Fix tar symbolic link issues on Windows; see:
@@ -70,38 +67,25 @@ jobs:
           mv tlapm-$TLAPS_VERSION tlapm
       - name: Check manifest.json format
         shell: bash
-        run: |
-          source ./bin/activate
-          python $SCRIPT_DIR/check_manifest_schema.py
+        run: python $SCRIPT_DIR/check_manifest_schema.py
       - name: Check manifest files
         shell: bash
-        run: |
-          source ./bin/activate
-          python $SCRIPT_DIR/check_manifest_files.py
+        run: python $SCRIPT_DIR/check_manifest_files.py
       - name: Check manifest feature flags
         shell: bash
-        run: |
-          source ./bin/activate
-          python $SCRIPT_DIR/check_manifest_features.py
+        run: python $SCRIPT_DIR/check_manifest_features.py
       - name: Parse all modules
         shell: bash
-        run: |
-          source ./bin/activate
-          python $SCRIPT_DIR/parse_modules.py
+        run: python $SCRIPT_DIR/parse_modules.py
       - name: Check small models
         shell: bash
-        run: |
-          source ./bin/activate
-          python $SCRIPT_DIR/check_small_models.py
+        run: python $SCRIPT_DIR/check_small_models.py
       - name: Smoke-test large models
         shell: bash
-        run: |
-          source ./bin/activate
-          python $SCRIPT_DIR/smoke_test_large_models.py
+        run: python $SCRIPT_DIR/smoke_test_large_models.py
       - name: Smoke-test manifest generation script
         shell: bash
         run: |
-          source ./bin/activate
           rm -r build
           python $SCRIPT_DIR/generate_manifest.py
           git diff -a

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,12 @@ jobs:
         run: python $SCRIPT_DIR/check_manifest_features.py
       - name: Parse all modules
         shell: bash
-        run: python $SCRIPT_DIR/parse_modules.py
+        run: |
+          python $SCRIPT_DIR/parse_modules.py                 \
+            --tools_jar_path tla2tools.jar                    \
+            --tlapm_lib_path tlapm/library                    \
+            --community_modules_path CommunityModules/modules \
+            --manifest_path manifest.json
       - name: Check small models
         shell: bash
         run: python $SCRIPT_DIR/check_small_models.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,10 @@ jobs:
         if: matrix.os == 'windows-latest'
       - name: Install python packages
         shell: bash
-        run: pip install -r $SCRIPT_DIR/requirements.txt
+        run: |
+          python -m venv .
+          source ./bin/activate
+          pip install -r $SCRIPT_DIR/requirements.txt
       - name: Download TLA⁺ dependencies
         run: |
           # Fix tar symbolic link issues on Windows; see:
@@ -67,25 +70,38 @@ jobs:
           mv tlapm-$TLAPS_VERSION tlapm
       - name: Check manifest.json format
         shell: bash
-        run: python $SCRIPT_DIR/check_manifest_schema.py
+        run: |
+          source ./bin/activate
+          python $SCRIPT_DIR/check_manifest_schema.py
       - name: Check manifest files
         shell: bash
-        run: python $SCRIPT_DIR/check_manifest_files.py
+        run: |
+          source ./bin/activate
+          python $SCRIPT_DIR/check_manifest_files.py
       - name: Check manifest feature flags
         shell: bash
-        run: python $SCRIPT_DIR/check_manifest_features.py
+        run: |
+          source ./bin/activate
+          python $SCRIPT_DIR/check_manifest_features.py
       - name: Parse all modules
         shell: bash
-        run: python $SCRIPT_DIR/parse_modules.py
+        run: |
+          source ./bin/activate
+          python $SCRIPT_DIR/parse_modules.py
       - name: Check small models
         shell: bash
-        run: python $SCRIPT_DIR/check_small_models.py
+        run: |
+          source ./bin/activate
+          python $SCRIPT_DIR/check_small_models.py
       - name: Smoke-test large models
         shell: bash
-        run: python $SCRIPT_DIR/smoke_test_large_models.py
+        run: |
+          source ./bin/activate
+          python $SCRIPT_DIR/smoke_test_large_models.py
       - name: Smoke-test manifest generation script
         shell: bash
         run: |
+          source ./bin/activate
           rm -r build
           python $SCRIPT_DIR/generate_manifest.py
           git diff -a

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,10 +84,20 @@ jobs:
             --manifest_path manifest.json
       - name: Check small models
         shell: bash
-        run: python $SCRIPT_DIR/check_small_models.py
+        run: |
+          python $SCRIPT_DIR/check_small_models.py                  \
+            --tools_jar_path tla2tools.jar                          \
+            --tlapm_lib_path tlapm/library                          \
+            --community_modules_jar_path CommunityModules-deps.jar  \
+            --manifest_path manifest.json
       - name: Smoke-test large models
         shell: bash
-        run: python $SCRIPT_DIR/smoke_test_large_models.py
+        run: |
+          python $SCRIPT_DIR/smoke_test_large_models.py             \
+            --tools_jar_path tla2tools.jar                          \
+            --tlapm_lib_path tlapm/library                          \
+            --community_modules_jar_path CommunityModules-deps.jar  \
+            --manifest_path manifest.json
       - name: Smoke-test manifest generation script
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ A central manifest of specs with descriptions and accounts of their various mode
 | 100 | Simplified Fast Paxos | <a href="https://github.com/tlaplus/Examples/tree/master/specifications/SimplifiedFastPaxos">Simplified version of Fast Paxos (Lamport, 2006)</a> | Lim Ngian Xin Terry, Gaurav Gandhi | |&#10004;| TLC, Naturals, FiniteSets, Integers | | |
 | 101 | Learn TLA⁺ Proofs | <a href="specifications/LearnProofs">Basic PlusCal algorithms and formal proofs of their correctness</a> | Andrew Helwer | &#10004; | &#10004; | Sequences, Naturals, Integers, TLAPS | &#10004; | |
 | 102 | Lexicographically-Least Circular Substring | <a href="specifications/LeastCircularSubstring">Booth's 1980 algorithm to find the lexicographically-least circular substring</a> | Andrew Helwer | | &#10004; | FiniteSets, Integers, Naturals, Sequences | &#10004; | |
-| 103 | Distributed Checkpoint Coordination | <a href="specifications/LeastCircularSubstring">Algorithm for coordinating checkpoint/snapshot leases in a Paxos ring</a> | Andrew Helwer | | &#10004; | FiniteSets, Naturals, Sequences, TLC | | |
+| 103 | Distributed Checkpoint Coordination | <a href="specifications/CheckpointCoordination">Algorithm for coordinating checkpoint/snapshot leases in a Paxos ring</a> | Andrew Helwer | | &#10004; | FiniteSets, Naturals, Sequences, TLC | | |
 
 ## License
 
@@ -146,10 +146,11 @@ To do this, you'll have to update the [`manifest.json`](manifest.json) file with
 If this process doesn't work for you, you can alternatively modify the [`.ciignore`](.ciignore) file to exclude your spec from validation.
 Otherwise, follow these directions:
 
-1. Ensure you have Python 3.X installed
+1. Ensure you have Python 3.11+ installed
 1. Download & extract tree-sitter-tlaplus ([zip](https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/refs/heads/main.zip), [tar.gz](https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/refs/heads/main.tar.gz)) to the root of the repository; ensure the extracted folder is named `tree-sitter-tlaplus`
 1. Open a shell and navigate to the repo root; ensure a C++ compiler is installed and on your path
     - On Windows, this might entail running the below script from the visual studio developer command prompt
+1. It is considered best practice to create & initialize a Python virtual environment to preserve your system package store; run `python -m venv .` then `source ./bin/activate` on Linux & macOS or `.\Scripts\activate.bat` on Windows (run `deactivate` to exit)
 1. Run `pip install -r .github/scripts/requirements.txt`
 1. Run `python .github/scripts/generate_manifest.py`
 1. Locate your spec's entry in the [`manifest.json`](manifest.json) file and ensure the following fields are filled out:

--- a/manifest.json
+++ b/manifest.json
@@ -1335,8 +1335,8 @@
       "description": "Spec of simplified Fast Paxos from Lamport's 2006 paper Fast Paxos",
       "source": "",
       "authors": [
-        "Lim Ngian Xin Terry",
-        "Gaurav Gandhi"
+        "Gaurav Gandhi",
+        "Lim Ngian Xin Terry"
       ],
       "tags": [],
       "modules": [


### PR DESCRIPTION
No longer do these scripts rely on various things being present at undocumented paths; all dependencies (tla2tools.jar path, manifest.json path, etc.) are now exposed using command line parameters. The scripts can be run from any working directory. These scripts also don't have any python package dependencies (tree-sitter etc.) so will be easy to run from the tlaplus/tlaplus repo CI instead of run.sh.

Also added a trigger to run the CI on a repository dispatch event, for the nightly tlaplus build to trigger.

Small amount of work necessary on tlaplus/tlaplus side but this is sufficient to close #77 