### PR TITLE
Bug fix in aba_asyn_byz.tla

### DIFF
--- a/specifications/aba-asyn-byz/aba_asyn_byz.tla
+++ b/specifications/aba-asyn-byz/aba_asyn_byz.tla
@@ -59,9 +59,13 @@ Init1 ==
   /\ nByz = 0
   /\ pc \in [ i \in Proc |-> "V1" ]  
   
-(* If there are less than F Byzantine processes, process i becomes faulty.*)
+(* If there are less than F Byzantine processes, process i becomes faulty. *)
+(* We requite i to be in an initial state (V0 or V1) to not break the      *)
+(* message counting abstraction.                                           *)
 BecomeByzantine(i) ==
   /\ nByz < F
+  /\ \/ pc[i] = "V1"
+     \/ pc[i] = "V0"
   /\ nByz' = nByz + 1  
   /\ pc' = [ pc EXCEPT ![i] = "BYZ" ]  
   /\ UNCHANGED << nSntE, nSntR, nRcvdE, nRcvdR >>


### PR DESCRIPTION
Following the discussion in https://github.com/tlaplus/Examples/issues/80 I discovered a bug in the encoding w.r.t handling of messages by faulty processes. If a process was to become faulty after having sent messages, its messages might be counted twice, while the original algorithm counts messages by distinct senders, that is, it counts senders rather than counting messages.

The proposed change is the minimal I could figure out to fix that. Processes can turn Byzantine only in an initial process state. @konnov, can you also please have a look?