### PR TITLE
Fix tar CI failure on windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,16 +16,16 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: windows-latest, shell: bash }
-        - { os: ubuntu-latest,  shell: bash  }
-        - { os: macos-latest,   shell: bash  }
+        - { os: windows-latest }
+        - { os: ubuntu-latest }
+        - { os: macos-latest }
       fail-fast: false
     env:
       SCRIPT_DIR: .github/scripts
       TLAPS_VERSION: 202210041448
     defaults:
       run:
-        shell: ${{ matrix.shell }} {0}
+        shell: bash
     steps:
       - name: Clone repo
         uses: actions/checkout@v2
@@ -38,31 +38,41 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
-      - name: Install python packages
-        shell: bash
-        run: pip install -r $SCRIPT_DIR/requirements.txt
       - name: Download TLA⁺ dependencies
         if: matrix.os == 'windows-latest'
         run: |
-          # Put all dependencies in their own directory to ensure they aren't included implicitly
-          mkdir deps
-          curl https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
-          7z x main.zip
-          rm main.zip
-      - name: Download TLA⁺ dependencies
-        run: |
+          # Install python packages
+          pip install -r $SCRIPT_DIR/requirements.txt
           # Put all dependencies in their own directory to ensure they aren't included implicitly
           mkdir deps
           # Get tree-sitter-tlaplus
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            curl -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
-            7z x main.zip
-            rm main.zip
-          else
-            wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
-            tar -xf main.tar.gz
-            rm main.tar.gz
-          fi
+          curl https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip -o main.zip
+          7z x main.zip
+          rm main.zip
+          mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
+          # Get TLA⁺ tools
+          mkdir deps/tools
+          curl http://nightly.tlapl.us/dist/tla2tools.jar -o deps/tools/tla2tools.jar
+          # Get TLA⁺ community modules
+          mkdir deps/community
+          curl https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar \
+                -o deps/community/modules.jar
+          # Get TLAPS modules
+          curl https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip -o tlaps.zip
+          7z x tlaps.zip
+          rm tlaps.zip
+          mv tlapm deps/tlapm
+      - name: Download TLA⁺ dependencies
+        if: matrix.os != 'windows-latest'
+        run: |
+          # Install python packages
+          pip install -r $SCRIPT_DIR/requirements.txt
+          # Put all dependencies in their own directory to ensure they aren't included implicitly
+          mkdir deps
+          # Get tree-sitter-tlaplus
+          wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
+          tar -xf main.tar.gz
+          rm main.tar.gz
           mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
           # Get TLA⁺ tools
           mkdir deps/tools
@@ -72,51 +82,39 @@ jobs:
           wget -nv https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar \
                 -O deps/community/modules.jar
           # Get TLAPS modules
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip
-            7z x $TLAPS_VERSION.zip
-            rm $TLAPS_VERSION.zip
-          else
-            wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
-            tar -xf $TLAPS_VERSION.tar.gz
-            rm $TLAPS_VERSION.tar.gz
-          fi
+          wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
+          tar -xf $TLAPS_VERSION.tar.gz
+          rm $TLAPS_VERSION.tar.gz
           mv tlapm-$TLAPS_VERSION deps/tlapm
-          # Install TLAPS on non-Windows environments
-          if [[ "${{ runner.os }}" != "Windows" ]]; then
-            if [[ "${{ runner.os }}" == "Linux" ]]; then
-              TLAPM_BIN_TYPE=x86_64-linux-gnu
-            elif [[ "${{ runner.os }}" == "macOS" ]]; then
-              TLAPM_BIN_TYPE=i386-darwin
-            else
-              echo "Unknown OS"
-              exit 1
-            fi
-            TLAPM_BIN="tlaps-1.5.0-$TLAPM_BIN_TYPE-inst.bin"
-            wget -nv https://github.com/tlaplus/tlapm/releases/download/$TLAPS_VERSION/$TLAPM_BIN
-            chmod +x $TLAPM_BIN
-            ./$TLAPM_BIN -d deps/tlapm-install
+          # Install TLAPS
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            TLAPM_BIN_TYPE=x86_64-linux-gnu
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            TLAPM_BIN_TYPE=i386-darwin
+          else
+            echo "Unknown OS"
+            exit 1
           fi
+          TLAPM_BIN="tlaps-1.5.0-$TLAPM_BIN_TYPE-inst.bin"
+          wget -nv https://github.com/tlaplus/tlapm/releases/download/$TLAPS_VERSION/$TLAPM_BIN
+          chmod +x $TLAPM_BIN
+          ./$TLAPM_BIN -d deps/tlapm-install
       - name: Check manifest.json format
-        shell: bash
         run: |
           python $SCRIPT_DIR/check_manifest_schema.py \
             --manifest_path manifest.json             \
             --schema_path manifest-schema.json
       - name: Check manifest files
-        shell: bash
         run: |
           python $SCRIPT_DIR/check_manifest_files.py  \
             --manifest_path manifest.json             \
             --ci_ignore_path .ciignore
       - name: Check manifest feature flags
-        shell: bash
         run: |
           python $SCRIPT_DIR/check_manifest_features.py \
             --manifest_path manifest.json               \
             --ts_path deps/tree-sitter-tlaplus
       - name: Parse all modules
-        shell: bash
         run: |
           python $SCRIPT_DIR/parse_modules.py                       \
             --tools_jar_path deps/tools/tla2tools.jar               \
@@ -124,7 +122,6 @@ jobs:
             --community_modules_jar_path deps/community/modules.jar \
             --manifest_path manifest.json
       - name: Check small models
-        shell: bash
         run: |
           python $SCRIPT_DIR/check_small_models.py                  \
             --tools_jar_path deps/tools/tla2tools.jar               \
@@ -132,7 +129,6 @@ jobs:
             --community_modules_jar_path deps/community/modules.jar \
             --manifest_path manifest.json
       - name: Smoke-test large models
-        shell: bash
         run: |
           python $SCRIPT_DIR/smoke_test_large_models.py             \
             --tools_jar_path deps/tools/tla2tools.jar               \
@@ -146,7 +142,6 @@ jobs:
             --tlapm_path deps/tlapm-install   \
             --manifest_path manifest.json
       - name: Smoke-test manifest generation script
-        shell: bash
         run: |
           rm -r deps/tree-sitter-tlaplus/build
           python $SCRIPT_DIR/generate_manifest.py \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Download TLA⁺ dependencies
         if: matrix.os == 'windows-latest'
         run: |
+          java --version
           # Install python packages
           pip install -r $SCRIPT_DIR/requirements.txt
           # Put all dependencies in their own directory to ensure they aren't included implicitly

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,16 +16,16 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: windows-latest, shell: msys2 }
-        - { os: ubuntu-latest,  shell: bash  }
-        - { os: macos-latest,   shell: bash  }
+        - { os: windows-latest }
+        - { os: ubuntu-latest }
+        - { os: macos-latest }
       fail-fast: false
     env:
       SCRIPT_DIR: .github/scripts
       TLAPS_VERSION: 202210041448
     defaults:
       run:
-        shell: ${{ matrix.shell }} {0}
+        shell: bash
     steps:
       - name: Clone repo
         uses: actions/checkout@v2
@@ -38,11 +38,7 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
-      - name: Install MSYS2 on Windows
-        uses: msys2/setup-msys2@v2
-        if: matrix.os == 'windows-latest'
       - name: Install python packages
-        shell: bash
         run: pip install -r $SCRIPT_DIR/requirements.txt
       - name: Download TLA⁺ dependencies
         run: |
@@ -51,7 +47,7 @@ jobs:
           # Get tree-sitter-tlaplus
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
-            unzip main.zip
+            7z x main.zip
             rm main.zip
           else
             wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
@@ -69,7 +65,7 @@ jobs:
           # Get TLAPS modules
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip
-            unzip $TLAPS_VERSION.zip
+            7z x $TLAPS_VERSION.zip
             rm $TLAPS_VERSION.zip
           else
             wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
@@ -83,6 +79,9 @@ jobs:
               TLAPM_BIN_TYPE=x86_64-linux-gnu
             elif [[ "${{ runner.os }}" == "macOS" ]]; then
               TLAPM_BIN_TYPE=i386-darwin
+            else
+              echo "Unknown OS ${{ runner.os }}"
+              exit 1
             fi
             TLAPM_BIN="tlaps-1.5.0-$TLAPM_BIN_TYPE-inst.bin"
             wget -nv https://github.com/tlaplus/tlapm/releases/download/$TLAPS_VERSION/$TLAPM_BIN

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: windows-latest, shell: msys2 }
+        - { os: windows-latest, shell: bash }
         - { os: ubuntu-latest,  shell: bash  }
         - { os: macos-latest,   shell: bash  }
       fail-fast: false
@@ -38,19 +38,24 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
-      - name: Install MSYS2 on Windows
-        uses: msys2/setup-msys2@v2
-        if: matrix.os == 'windows-latest'
       - name: Install python packages
         shell: bash
         run: pip install -r $SCRIPT_DIR/requirements.txt
+      - name: Download TLA⁺ dependencies
+        if: matrix.os == 'windows-latest'
+        run: |
+          # Put all dependencies in their own directory to ensure they aren't included implicitly
+          mkdir deps
+          curl https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
+          7z x main.zip
+          rm main.zip
       - name: Download TLA⁺ dependencies
         run: |
           # Put all dependencies in their own directory to ensure they aren't included implicitly
           mkdir deps
           # Get tree-sitter-tlaplus
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
+            curl -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
             7z x main.zip
             rm main.zip
           else

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,16 +16,16 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: windows-latest }
-        - { os: ubuntu-latest }
-        - { os: macos-latest }
+        - { os: windows-latest, shell: msys2 }
+        - { os: ubuntu-latest,  shell: bash  }
+        - { os: macos-latest,   shell: bash  }
       fail-fast: false
     env:
       SCRIPT_DIR: .github/scripts
       TLAPS_VERSION: 202210041448
     defaults:
       run:
-        shell: bash
+        shell: ${{ matrix.shell }} {0}
     steps:
       - name: Clone repo
         uses: actions/checkout@v2
@@ -38,7 +38,11 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
+      - name: Install MSYS2 on Windows
+        uses: msys2/setup-msys2@v2
+        if: matrix.os == 'windows-latest'
       - name: Install python packages
+        shell: bash
         run: pip install -r $SCRIPT_DIR/requirements.txt
       - name: Download TLA⁺ dependencies
         run: |
@@ -80,7 +84,7 @@ jobs:
             elif [[ "${{ runner.os }}" == "macOS" ]]; then
               TLAPM_BIN_TYPE=i386-darwin
             else
-              echo "Unknown OS ${{ runner.os }}"
+              echo "Unknown OS"
               exit 1
             fi
             TLAPM_BIN="tlaps-1.5.0-$TLAPM_BIN_TYPE-inst.bin"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,6 @@ jobs:
       - name: Install MSYS2 on Windows
         uses: msys2/setup-msys2@v2
         if: matrix.os == 'windows-latest'
-        with:
-          msystem: UCRT64
       - name: Install python packages
         shell: bash
         run: pip install -r $SCRIPT_DIR/requirements.txt
@@ -55,7 +53,7 @@ jobs:
           export MSYS=winsymlinks:lnk
           # Get tree-sitter-tlaplus
           wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
-          tar -xf main.tar.gz
+          tar -xf main.tar.gz || tar -xf main.tar.gz
           rm main.tar.gz
           mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
           # Get TLA⁺ tools
@@ -67,7 +65,7 @@ jobs:
                 -O deps/community/modules.jar
           # Get TLAPS modules
           wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
-          tar --delay-directory-restore -xf $TLAPS_VERSION.tar.gz
+          tar -xf $TLAPS_VERSION.tar.gz || tar -xf $TLAPS_VERSION.tar.gz
           rm $TLAPS_VERSION.tar.gz
           mv tlapm-$TLAPS_VERSION deps/tlapm
           # Install TLAPS on non-Windows environments

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,20 +52,20 @@ jobs:
           # https://github.com/msys2/MSYS2-packages/issues/1216
           export MSYS=winsymlinks:lnk
           # Get tree-sitter-tlaplus
-          wget https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
-          tar -xf main.tar.gz
+          wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
+          tar --no-overwrite-dir -xf main.tar.gz
           rm main.tar.gz
           mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
           # Get TLA⁺ tools
           mkdir deps/tools
-          wget http://nightly.tlapl.us/dist/tla2tools.jar -O deps/tools/tla2tools.jar
+          wget -nv http://nightly.tlapl.us/dist/tla2tools.jar -O deps/tools/tla2tools.jar
           # Get TLA⁺ community modules
           mkdir deps/community
-          wget https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar \
+          wget -nv https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar \
                 -O deps/community/modules.jar
           # Get TLAPS modules
-          wget https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
-          tar -xf $TLAPS_VERSION.tar.gz
+          wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
+          tar --no-overwrite-dir -xf $TLAPS_VERSION.tar.gz
           rm $TLAPS_VERSION.tar.gz
           mv tlapm-$TLAPS_VERSION deps/tlapm
           # Install TLAPS on non-Windows environments

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,20 +46,20 @@ jobs:
           # Put all dependencies in their own directory to ensure they aren't included implicitly
           mkdir deps
           # Get tree-sitter-tlaplus
-          curl https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
+          curl -O https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
           7z x main.zip
           rm main.zip
           mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
           # Get TLA⁺ tools
           mkdir deps/tools
-          curl http://nightly.tlapl.us/dist/tla2tools.jar
+          curl -O http://nightly.tlapl.us/dist/tla2tools.jar
           mv tla2tools.jar deps/tools/tla2tools.jar
           # Get TLA⁺ community modules
           mkdir deps/community
-          curl https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar
+          curl -O https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar
           mv CommunityModules-deps.jar deps/community/modules.jar
           # Get TLAPS modules
-          curl https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip
+          curl -O https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip
           7z x $TLAPS_VERSION.zip
           rm $TLAPS_VERSION.zip
           mv tlapm-$TLAPS_VERSION deps/tlapm

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,9 +49,15 @@ jobs:
           # Put all dependencies in their own directory to ensure they aren't included implicitly
           mkdir deps
           # Get tree-sitter-tlaplus
-          wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
-          tar -xf main.tar.gz || tar -xf main.tar.gz
-          rm main.tar.gz
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
+            unzip main.zip
+            rm main.zip
+          else
+            wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
+            tar -xf main.tar.gz
+            rm main.tar.gz
+          fi
           mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
           # Get TLA⁺ tools
           mkdir deps/tools
@@ -61,9 +67,15 @@ jobs:
           wget -nv https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar \
                 -O deps/community/modules.jar
           # Get TLAPS modules
-          wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
-          tar -xf $TLAPS_VERSION.tar.gz || tar -xf $TLAPS_VERSION.tar.gz
-          rm $TLAPS_VERSION.tar.gz
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip
+            unzip $TLAPS_VERSION.zip
+            rm $TLAPS_VERSION.zip
+          else
+            wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
+            tar -xf $TLAPS_VERSION.tar.gz
+            rm $TLAPS_VERSION.tar.gz
+          fi
           mv tlapm-$TLAPS_VERSION deps/tlapm
           # Install TLAPS on non-Windows environments
           if [[ "${{ runner.os }}" != "Windows" ]]; then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,22 +46,23 @@ jobs:
           # Put all dependencies in their own directory to ensure they aren't included implicitly
           mkdir deps
           # Get tree-sitter-tlaplus
-          curl https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip -o main.zip
+          curl https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
           7z x main.zip
           rm main.zip
           mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
           # Get TLA⁺ tools
           mkdir deps/tools
-          curl http://nightly.tlapl.us/dist/tla2tools.jar -o deps/tools/tla2tools.jar
+          curl http://nightly.tlapl.us/dist/tla2tools.jar
+          mv tla2tools.jar deps/tools/tla2tools.jar
           # Get TLA⁺ community modules
           mkdir deps/community
-          curl https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar \
-                -o deps/community/modules.jar
+          curl https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar
+          mv CommunityModules-deps.jar deps/community/modules.jar
           # Get TLAPS modules
-          curl https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip -o tlaps.zip
-          7z x tlaps.zip
-          rm tlaps.zip
-          mv tlapm deps/tlapm
+          curl https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip
+          7z x $TLAPS_VERSION.zip
+          rm $TLAPS_VERSION.zip
+          mv tlapm-$TLAPS_VERSION deps/tlapm
       - name: Download TLA⁺ dependencies
         if: matrix.os != 'windows-latest'
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
                 -O deps/community/modules.jar
           # Get TLAPS modules
           wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
-          tar -xf $TLAPS_VERSION.tar.gz
+          tar --delay-directory-restore -xf $TLAPS_VERSION.tar.gz
           rm $TLAPS_VERSION.tar.gz
           mv tlapm-$TLAPS_VERSION deps/tlapm
           # Install TLAPS on non-Windows environments

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Install MSYS2 on Windows
         uses: msys2/setup-msys2@v2
         if: matrix.os == 'windows-latest'
+        with:
+          msystem: UCRT64
       - name: Install python packages
         shell: bash
         run: pip install -r $SCRIPT_DIR/requirements.txt
@@ -53,7 +55,7 @@ jobs:
           export MSYS=winsymlinks:lnk
           # Get tree-sitter-tlaplus
           wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
-          tar --no-overwrite-dir -xf main.tar.gz
+          tar -xf main.tar.gz
           rm main.tar.gz
           mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
           # Get TLA⁺ tools
@@ -65,7 +67,7 @@ jobs:
                 -O deps/community/modules.jar
           # Get TLAPS modules
           wget -nv https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.tar.gz
-          tar --no-overwrite-dir -xf $TLAPS_VERSION.tar.gz
+          tar -xf $TLAPS_VERSION.tar.gz
           rm $TLAPS_VERSION.tar.gz
           mv tlapm-$TLAPS_VERSION deps/tlapm
           # Install TLAPS on non-Windows environments
@@ -76,7 +78,7 @@ jobs:
               TLAPM_BIN_TYPE=i386-darwin
             fi
             TLAPM_BIN="tlaps-1.5.0-$TLAPM_BIN_TYPE-inst.bin"
-            wget https://github.com/tlaplus/tlapm/releases/download/$TLAPS_VERSION/$TLAPM_BIN
+            wget -nv https://github.com/tlaplus/tlapm/releases/download/$TLAPS_VERSION/$TLAPM_BIN
             chmod +x $TLAPM_BIN
             ./$TLAPM_BIN -d deps/tlapm-install
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,20 +46,20 @@ jobs:
           # Put all dependencies in their own directory to ensure they aren't included implicitly
           mkdir deps
           # Get tree-sitter-tlaplus
-          curl -O https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
+          curl -LO https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.zip
           7z x main.zip
           rm main.zip
           mv tree-sitter-tlaplus-main deps/tree-sitter-tlaplus
           # Get TLA⁺ tools
           mkdir deps/tools
-          curl -O http://nightly.tlapl.us/dist/tla2tools.jar
+          curl -LO http://nightly.tlapl.us/dist/tla2tools.jar
           mv tla2tools.jar deps/tools/tla2tools.jar
           # Get TLA⁺ community modules
           mkdir deps/community
-          curl -O https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar
+          curl -LO https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar
           mv CommunityModules-deps.jar deps/community/modules.jar
           # Get TLAPS modules
-          curl -O https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip
+          curl -LO https://github.com/tlaplus/tlapm/archive/refs/tags/$TLAPS_VERSION.zip
           7z x $TLAPS_VERSION.zip
           rm $TLAPS_VERSION.zip
           mv tlapm-$TLAPS_VERSION deps/tlapm

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,9 +48,6 @@ jobs:
         run: |
           # Put all dependencies in their own directory to ensure they aren't included implicitly
           mkdir deps
-          # Fix tar symbolic link issues on Windows; see:
-          # https://github.com/msys2/MSYS2-packages/issues/1216
-          export MSYS=winsymlinks:lnk
           # Get tree-sitter-tlaplus
           wget -nv https://github.com/tlaplus-community/tree-sitter-tlaplus/archive/main.tar.gz
           tar -xf main.tar.gz || tar -xf main.tar.gz


### PR DESCRIPTION
I think the lesson here is don't try to use tar on windows. Should probably do a squash-merge because a lot of these commits were small changes trying to get the CI to pass.