### PR TITLE
Configure TLAPM install to proceed if exiting with nonzero error code

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,6 +110,7 @@ jobs:
           wget -nv https://github.com/tlaplus/tlapm/releases/download/$TLAPS_VERSION/$TLAPM_BIN
           chmod +x $TLAPM_BIN
           # Workaround for https://github.com/tlaplus/tlapm/issues/88
+          set +e
           for ((attempt = 1; attempt <= 5; attempt++)); do
             rm -rf deps/tlapm-install
             ./$TLAPM_BIN -d deps/tlapm-install


### PR DESCRIPTION
Github actions appears to run `set -e` by default, so the tlapm install failure will abort the script and ignore the retry logic around it. We counteract this by running `set +e` right before the tlapm install retry loop.