### PR TITLE
Print out TLC command on failure for ease of local reproducibility

### DIFF
--- a/.github/scripts/check_small_models.py
+++ b/.github/scripts/check_small_models.py
@@ -49,22 +49,23 @@ def check_model(module_path, model, expected_runtime):
     match tlc_result:
         case CompletedProcess():
             logging.info(f'{model_path} in {end_time - start_time:.1f}s vs. {expected_runtime.seconds}s expected')
+            output = ' '.join(tlc_result.args) + '\n' + tlc_result.stdout
             expected_result = model['result']
             actual_result = tla_utils.resolve_tlc_exit_code(tlc_result.returncode)
             if expected_result != actual_result:
                 logging.error(f'Model {model_path} expected result {expected_result} but got {actual_result}')
-                logging.error(tlc_result.stdout)
+                logging.error(output)
                 return False
             if tla_utils.is_state_count_valid(model) and tla_utils.has_state_count(model):
                 state_count_info = tla_utils.extract_state_count_info(tlc_result.stdout)
                 if state_count_info is None:
                     logging.error("Failed to find state info in TLC output")
-                    logging.error(tlc_result.stdout)
+                    logging.error(output)
                     return False
                 if not tla_utils.is_state_count_info_correct(model, *state_count_info):
                     logging.error("Recorded state count info differed from actual state counts:")
                     logging.error(f"(distinct/total/depth); expected: {tla_utils.get_state_count_info(model)}, actual: {state_count_info}")
-                    logging.error(tlc_result.stdout)
+                    logging.error(output)
                     return False
             return True
         case TimeoutExpired():


### PR DESCRIPTION
Previously only the TLC output was printed; this will ease efforts to reproduce failures