### PR TITLE
Add Apalache to CI

### DIFF
--- a/.github/scripts/check_manifest_features.py
+++ b/.github/scripts/check_manifest_features.py
@@ -230,7 +230,6 @@ def check_features(parser, queries, manifest, examples_root):
 if __name__ == '__main__':
     parser = ArgumentParser(description='Checks metadata in tlaplus/examples manifest.json against module and model files in repository.')
     parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
-    parser.add_argument('--ts_path', help='[DEPRECATED, UNUSED] Path to tree-sitter-tlaplus directory', required=False)
     args = parser.parse_args()
 
     manifest_path = normpath(args.manifest_path)

--- a/.github/scripts/check_manifest_features.py
+++ b/.github/scripts/check_manifest_features.py
@@ -112,7 +112,8 @@ tlc_modules = {
     'Sequences',
     'TLC',
     'TLCExt',
-    'Toolbox'
+    'Toolbox',
+    'Apalache'
 }
 
 # All the standard modules available when using TLAPS

--- a/.github/scripts/check_proofs.py
+++ b/.github/scripts/check_proofs.py
@@ -9,26 +9,30 @@ import subprocess
 from timeit import default_timer as timer
 import tla_utils
 
-logging.basicConfig(level=logging.INFO)
-
 parser = ArgumentParser(description='Validate all proofs in all modules with TLAPM.')
 parser.add_argument('--tlapm_path', help='Path to TLAPM install dir; should have bin and lib subdirs', required=True)
 parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
 parser.add_argument('--skip', nargs='+', help='Space-separated list of .tla modules to skip checking', required=False, default=[])
+parser.add_argument('--only', nargs='+', help='If provided, only check proofs in this space-separated list', required=False, default=[])
+parser.add_argument('--verbose', help='Set logging output level to debug', action='store_true')
 args = parser.parse_args()
 
 tlapm_path = normpath(args.tlapm_path)
 manifest_path = normpath(args.manifest_path)
 manifest = tla_utils.load_json(manifest_path)
 examples_root = dirname(manifest_path)
-skip_modules = [normpath(path) for path in args.skip]
+skip_modules = args.skip
+only_modules = args.only
+
+logging.basicConfig(level = logging.DEBUG if args.verbose else logging.INFO)
 
 proof_module_paths = [
     module['path']
     for spec in manifest['specifications']
     for module in spec['modules']
         if 'proof' in module['features']
-        and normpath(module['path']) not in skip_modules
+        and module['path'] not in skip_modules
+        and (only_modules == [] or model['path'] in only_models)
 ]
 
 for path in skip_modules:
@@ -45,14 +49,19 @@ for module_path in proof_module_paths:
         [
             tlapm_path, module_path,
             '-I', module_dir
-        ], capture_output=True
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True
     )
     end_time = timer()
     logging.info(f'Checked proofs in {end_time - start_time:.1f}s')
     if tlapm.returncode != 0:
         logging.error(f'Proof checking failed in {module_path}:')
-        logging.error(tlapm.stderr.decode('utf-8'))
+        logging.error(tlapm.stdout)
         success = False
+    else:
+        logging.debug(tlapm.stdout)
 
 exit(0 if success else 1)
 

--- a/.github/scripts/generate_manifest.py
+++ b/.github/scripts/generate_manifest.py
@@ -167,7 +167,6 @@ if __name__ == '__main__':
     parser = ArgumentParser(description='Generates a new manifest.json derived from files in the repo.')
     parser.add_argument('--manifest_path', help='Path to the current tlaplus/examples manifest.json file', default='manifest.json')
     parser.add_argument('--ci_ignore_path', help='Path to the CI ignore file', default='.ciignore')
-    parser.add_argument('--ts_path', help='[DEPRECATED, UNUSED] Path to tree-sitter-tlaplus directory', required=False)
     args = parser.parse_args()
 
     manifest_path = normpath(args.manifest_path)

--- a/.github/scripts/linux-setup.sh
+++ b/.github/scripts/linux-setup.sh
@@ -40,6 +40,9 @@ main() {
   # Get TLA⁺ tools
   mkdir -p "$DEPS_DIR/tools"
   wget -nv http://nightly.tlapl.us/dist/tla2tools.jar -P "$DEPS_DIR/tools"
+  # Get Apalache
+  wget -nv https://github.com/informalsystems/apalache/releases/download/v0.44.10/apalache.tgz -O /tmp/apalache.tgz
+  tar -xzf /tmp/apalache.tgz --directory "$DEPS_DIR"
   # Get TLA⁺ community modules
   mkdir -p "$DEPS_DIR/community"
   wget -nv https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar \

--- a/.github/scripts/linux-setup.sh
+++ b/.github/scripts/linux-setup.sh
@@ -41,7 +41,7 @@ main() {
   mkdir -p "$DEPS_DIR/tools"
   wget -nv http://nightly.tlapl.us/dist/tla2tools.jar -P "$DEPS_DIR/tools"
   # Get Apalache
-  wget -nv https://github.com/informalsystems/apalache/releases/download/v0.44.10/apalache.tgz -O /tmp/apalache.tgz
+  wget -nv https://github.com/informalsystems/apalache/releases/latest/download/apalache.tgz -O /tmp/apalache.tgz
   tar -xzf /tmp/apalache.tgz --directory "$DEPS_DIR"
   # Get TLA⁺ community modules
   mkdir -p "$DEPS_DIR/community"

--- a/.github/scripts/parse_modules.py
+++ b/.github/scripts/parse_modules.py
@@ -27,8 +27,8 @@ tlaps_modules = normpath(args.tlapm_lib_path)
 community_modules = normpath(args.community_modules_jar_path)
 manifest_path = normpath(args.manifest_path)
 examples_root = dirname(manifest_path)
-skip_modules = [normpath(path) for path in args.skip]
-only_modules = [normpath(path) for path in args.only]
+skip_modules = args.skip
+only_modules = args.only
 
 def parse_module(path):
     """
@@ -63,8 +63,8 @@ modules = [
     tla_utils.from_cwd(examples_root, module['path'])
     for spec in manifest['specifications']
     for module in spec['modules']
-        if normpath(module['path']) not in skip_modules
-        and (only_modules == [] or normpath(module['path']) in only_modules)
+        if module['path'] not in skip_modules
+        and (only_modules == [] or module['path'] in only_modules)
 ]
 
 for path in skip_modules:

--- a/.github/scripts/parse_modules.py
+++ b/.github/scripts/parse_modules.py
@@ -6,12 +6,13 @@ from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor
 import logging
 from os import cpu_count
-from os.path import dirname, normpath, pathsep
+from os.path import join, dirname, normpath, pathsep
 import subprocess
 import tla_utils
 
 parser = ArgumentParser(description='Parses all TLA+ modules in the tlaplus/examples repo using SANY.')
 parser.add_argument('--tools_jar_path', help='Path to the tla2tools.jar file', required=True)
+parser.add_argument('--apalache_path', help='Path to the Apalache directory', required=True)
 parser.add_argument('--tlapm_lib_path', help='Path to the TLA+ proof manager module directory; .tla files should be in this directory', required=True)
 parser.add_argument('--community_modules_jar_path', help='Path to the CommunityModules-deps.jar file', required=True)
 parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
@@ -23,6 +24,7 @@ args = parser.parse_args()
 logging.basicConfig(level = logging.DEBUG if args.verbose else logging.INFO)
 
 tools_jar_path = normpath(args.tools_jar_path)
+apalache_jar_path = normpath(join(args.apalache_path, 'lib', 'apalache.jar'))
 tlaps_modules = normpath(args.tlapm_lib_path)
 community_modules = normpath(args.community_modules_jar_path)
 manifest_path = normpath(args.manifest_path)
@@ -36,7 +38,13 @@ def parse_module(path):
     """
     logging.info(path)
     # Jar paths must go first
-    search_paths = pathsep.join([tools_jar_path, dirname(path), community_modules, tlaps_modules])
+    search_paths = pathsep.join([
+        tools_jar_path,
+        apalache_jar_path,
+        dirname(path),
+        community_modules,
+        tlaps_modules
+    ])
     sany = subprocess.run([
             'java',
             '-cp', search_paths,

--- a/.github/scripts/smoke_test_large_models.py
+++ b/.github/scripts/smoke_test_large_models.py
@@ -13,18 +13,23 @@ import tla_utils
 
 parser = ArgumentParser(description='Smoke-tests all larger TLA+ models in the tlaplus/examples repo using TLC.')
 parser.add_argument('--tools_jar_path', help='Path to the tla2tools.jar file', required=True)
+parser.add_argument('--apalache_path', help='Path to the Apalache directory', required=True)
 parser.add_argument('--tlapm_lib_path', help='Path to the TLA+ proof manager module directory; .tla files should be in this directory', required=True)
 parser.add_argument('--community_modules_jar_path', help='Path to the CommunityModules-deps.jar file', required=True)
 parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
 parser.add_argument('--skip', nargs='+', help='Space-separated list of models to skip checking', required=False, default=[])
+parser.add_argument('--only', nargs='+', help='If provided, only check models in this space-separated list', required=False, default=[])
+parser.add_argument('--verbose', help='Set logging output level to debug', action='store_true')
 args = parser.parse_args()
 
 tools_jar_path = normpath(args.tools_jar_path)
+apalache_path = normpath(args.apalache_path)
 tlapm_lib_path = normpath(args.tlapm_lib_path)
 community_jar_path = normpath(args.community_modules_jar_path)
 manifest_path = normpath(args.manifest_path)
 examples_root = dirname(manifest_path)
-skip_models = [normpath(path) for path in args.skip]
+skip_models = args.skip
+only_models = args.only
 
 def check_model(module_path, model):
     module_path = tla_utils.from_cwd(examples_root, module_path)
@@ -33,6 +38,7 @@ def check_model(module_path, model):
     smoke_test_timeout_in_seconds = 5
     tlc_result = tla_utils.check_model(
         tools_jar_path,
+        apalache_path,
         module_path,
         model_path,
         tlapm_lib_path,
@@ -42,6 +48,7 @@ def check_model(module_path, model):
     )
     match tlc_result:
         case TimeoutExpired():
+            logging.debug(tlc_result.stdout)
             return True
         case CompletedProcess():
             logging.warning(f'Model {model_path} finished quickly, within {smoke_test_timeout_in_seconds} seconds; consider labeling it a small model')
@@ -56,7 +63,7 @@ def check_model(module_path, model):
             logging.error(f'Unhandled TLC result type {type(tlc_result)}: {tlc_result}')
             return False
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level = logging.DEBUG if args.verbose else logging.INFO)
 
 manifest = tla_utils.load_json(manifest_path)
 
@@ -66,7 +73,10 @@ large_models = [
     for module in spec['modules']
     for model in module['models']
         if model['size'] != 'small'
-        and normpath(model['path']) not in skip_models
+        and model['path'] not in skip_models
+        and (only_models == [] or model['path'] in only_models)
+    ],
+    key = lambda m: m[2],
 ]
 
 for path in skip_models:

--- a/.github/scripts/smoke_test_large_models.py
+++ b/.github/scripts/smoke_test_large_models.py
@@ -75,8 +75,6 @@ large_models = [
         if model['size'] != 'small'
         and model['path'] not in skip_models
         and (only_models == [] or model['path'] in only_models)
-    ],
-    key = lambda m: m[2],
 ]
 
 for path in skip_models:

--- a/.github/scripts/translate_pluscal.py
+++ b/.github/scripts/translate_pluscal.py
@@ -24,8 +24,8 @@ logging.basicConfig(level = logging.DEBUG if args.verbose else logging.INFO)
 tools_path = normpath(args.tools_jar_path)
 manifest_path = normpath(args.manifest_path)
 examples_root = dirname(manifest_path)
-skip_modules = [normpath(path) for path in args.skip]
-only_modules = [normpath(path) for path in args.only]
+skip_modules = args.skip
+only_modules = args.only
 
 manifest = tla_utils.load_json(manifest_path)
 
@@ -35,8 +35,8 @@ modules = [
     for spec in manifest['specifications']
     for module in spec['modules']
         if 'pluscal' in module['features']
-        and normpath(module['path']) not in skip_modules
-        and (only_modules == [] or normpath(module['path']) in only_modules)
+        and module['path'] not in skip_modules
+        and (only_modules == [] or module['path'] in only_modules)
 ]
 
 for path in skip_modules:
@@ -53,6 +53,7 @@ def translate_module(module_path):
     match result:
         case CompletedProcess():
             if result.returncode == 0:
+                logging.debug(result.stdout)
                 return True
             else:
                 logging.error(f'Module {module_path} conversion failed with return code {result.returncode}; output:\n{result.stdout}')

--- a/.github/scripts/unicode_conversion.py
+++ b/.github/scripts/unicode_conversion.py
@@ -26,8 +26,8 @@ tlauc_path = normpath(args.tlauc_path)
 to_ascii = args.to_ascii
 manifest_path = normpath(args.manifest_path)
 examples_root = dirname(manifest_path)
-skip_modules = [normpath(path) for path in args.skip]
-only_modules = [normpath(path) for path in args.only]
+skip_modules = args.skip
+only_modules = args.only
 
 manifest = tla_utils.load_json(manifest_path)
 
@@ -36,8 +36,8 @@ modules = [
     tla_utils.from_cwd(examples_root, module['path'])
     for spec in manifest['specifications']
     for module in spec['modules']
-        if normpath(module['path']) not in skip_modules
-        and (only_modules == [] or normpath(module['path']) in only_modules)
+        if module['path'] not in skip_modules
+        and (only_modules == [] or module['path'] in only_modules)
 ]
 
 for path in skip_modules:
@@ -54,6 +54,7 @@ def convert_module(module_path):
     match result:
         case CompletedProcess():
             if result.returncode == 0:
+                logging.debug(result.stdout)
                 return True
             else:
                 logging.error(f'Module {module_path} conversion failed with return code {result.returncode}; output:\n{result.stdout}')

--- a/.github/scripts/unicode_number_set_shim.py
+++ b/.github/scripts/unicode_number_set_shim.py
@@ -117,7 +117,6 @@ def write_module(examples_root, module_path, module_bytes):
 if __name__ == '__main__':
     parser = ArgumentParser(description='Adds ℕ/ℤ/ℝ Unicode number set shim definitions to modules as needed.')
     parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
-    parser.add_argument('--ts_path', help='[DEPRECATED, UNUSED] Path to tree-sitter-tlaplus directory', required=False)
     parser.add_argument('--skip', nargs='+', help='Space-separated list of .tla modules to skip', required=False, default=[])
     parser.add_argument('--only', nargs='+', help='If provided, only modify models in this space-separated list', required=False, default=[])
     args = parser.parse_args()
@@ -125,8 +124,8 @@ if __name__ == '__main__':
     manifest_path = normpath(args.manifest_path)
     manifest = tla_utils.load_json(manifest_path)
     examples_root = dirname(manifest_path)
-    skip_modules = [normpath(path) for path in args.skip]
-    only_modules = [normpath(path) for path in args.only]
+    skip_modules = args.skip
+    only_modules = args.only
 
     TLAPLUS_LANGUAGE = Language(tree_sitter_tlaplus.language(), 'tlaplus')
     parser = Parser()
@@ -137,8 +136,8 @@ if __name__ == '__main__':
         module['path']
         for spec in manifest['specifications']
         for module in spec['modules']
-            if normpath(module['path']) not in skip_modules
-            and (only_modules == [] or normpath(module['path']) in only_modules)
+            if module['path'] not in skip_modules
+            and (only_modules == [] or module['path'] in only_modules)
     ]
 
     for module_path in modules:

--- a/.github/scripts/windows-setup.sh
+++ b/.github/scripts/windows-setup.sh
@@ -37,6 +37,11 @@ main() {
   # Get TLA⁺ tools
   mkdir -p "$DEPS_DIR/tools"
   curl http://nightly.tlapl.us/dist/tla2tools.jar --output "$DEPS_DIR/tools/tla2tools.jar"
+  # Get Apalache
+  curl https://github.com/informalsystems/apalache/releases/download/v0.44.10/apalache.zip --output apalache.zip
+  7z x apalache.zip
+  mv apalache "$DEPS_DIR/"
+  rm apalache.zip
   # Get TLA⁺ community modules
   mkdir -p "$DEPS_DIR/community"
   curl -L https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar --output "$DEPS_DIR/community/modules.jar"

--- a/.github/scripts/windows-setup.sh
+++ b/.github/scripts/windows-setup.sh
@@ -38,7 +38,7 @@ main() {
   mkdir -p "$DEPS_DIR/tools"
   curl http://nightly.tlapl.us/dist/tla2tools.jar --output "$DEPS_DIR/tools/tla2tools.jar"
   # Get Apalache
-  curl https://github.com/informalsystems/apalache/releases/download/v0.44.10/apalache.zip --output apalache.zip
+  curl https://github.com/informalsystems/apalache/releases/latest/download/apalache.zip --output apalache.zip
   7z x apalache.zip
   mv apalache "$DEPS_DIR/"
   rm apalache.zip

--- a/.github/scripts/windows-setup.sh
+++ b/.github/scripts/windows-setup.sh
@@ -38,7 +38,7 @@ main() {
   mkdir -p "$DEPS_DIR/tools"
   curl http://nightly.tlapl.us/dist/tla2tools.jar --output "$DEPS_DIR/tools/tla2tools.jar"
   # Get Apalache
-  curl https://github.com/informalsystems/apalache/releases/latest/download/apalache.zip --output apalache.zip
+  curl -L https://github.com/informalsystems/apalache/releases/latest/download/apalache.zip --output apalache.zip
   7z x apalache.zip
   mv apalache "$DEPS_DIR/"
   rm apalache.zip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -122,6 +122,8 @@ jobs:
           if [ ${{ matrix.unicode }} ]; then
             # This redefines Real so cannot be shimmed
             SKIP+=("specifications/SpecifyingSystems/RealTime/MCRealTimeHourClock.cfg")
+            # Apalache does not yet support Unicode
+            SKIP+=("specifications/EinsteinRiddle/Einstein.cfg")
           fi
           python $SCRIPT_DIR/check_small_models.py                       \
             --tools_jar_path $DEPS_DIR/tools/tla2tools.jar               \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,6 +110,7 @@ jobs:
           fi
           python $SCRIPT_DIR/parse_modules.py                            \
             --tools_jar_path $DEPS_DIR/tools/tla2tools.jar               \
+            --apalache_path $DEPS_DIR/apalache                           \
             --tlapm_lib_path $DEPS_DIR/tlapm/library                     \
             --community_modules_jar_path $DEPS_DIR/community/modules.jar \
             --manifest_path manifest.json                                \
@@ -124,6 +125,7 @@ jobs:
           fi
           python $SCRIPT_DIR/check_small_models.py                       \
             --tools_jar_path $DEPS_DIR/tools/tla2tools.jar               \
+            --apalache_path $DEPS_DIR/apalache                           \
             --tlapm_lib_path $DEPS_DIR/tlapm/library                     \
             --community_modules_jar_path $DEPS_DIR/community/modules.jar \
             --manifest_path manifest.json                                \
@@ -140,6 +142,7 @@ jobs:
           fi
           python $SCRIPT_DIR/smoke_test_large_models.py                  \
             --tools_jar_path $DEPS_DIR/tools/tla2tools.jar               \
+            --apalache_path $DEPS_DIR/apalache                           \
             --tlapm_lib_path $DEPS_DIR/tlapm/library                     \
             --community_modules_jar_path $DEPS_DIR/community/modules.jar \
             --manifest_path manifest.json                                \

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ tree-sitter-tlaplus/
 ## Ignore tools/ folder created by .devcontainer.json
 tools/
 
+# Ignore directory created by Apalache
+_apalache-out
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Here is a list of specs included in this repository, with links to the relevant 
 | [Snapshot Key-Value Store](specifications/KeyValueStore)                                            | Andrew Helwer, Murat Demirbas                       |          |             |    ✔    |     ✔     |          |
 | [Chang-Roberts Algorithm for Leader Election in a Ring](specifications/chang_roberts)               | Stephan Merz                                        |          |             |    ✔    |     ✔     |          |
 | [MultiPaxos in SMR-Style](specifications/MultiPaxos-SMR)                                            | Guanzhou Hu                                         |          |             |    ✔    |     ✔     |          |
+| [Einstein's Riddle](specifications/EinsteinRiddle)                                                  | Isaac DeFrain, Giuliano Losa                        |          |             |         |           |    ✔     |
 | [Resource Allocator](specifications/allocator)                                                      | Stephan Merz                                        |          |             |         |     ✔     |          |
 | [Transitive Closure](specifications/TransitiveClosure)                                              | Stephan Merz                                        |          |             |         |     ✔     |          |
 | [Atomic Commitment Protocol](specifications/acp)                                                    | Stephan Merz                                        |          |             |         |     ✔     |          |
@@ -70,7 +71,6 @@ Here is a list of specs included in this repository, with links to the relevant 
 | [Multi-Car Elevator System](specifications/MultiCarElevator)                                        | Andrew Helwer                                       |          |             |         |     ✔     |          |
 | [Nano Blockchain Protocol](specifications/NanoBlockchain)                                           | Andrew Helwer                                       |          |             |         |     ✔     |          |
 | [The Readers-Writers Problem](specifications/ReadersWriters)                                        | Isaac DeFrain                                       |          |             |         |     ✔     |          |
-| [Einstein's Riddle](specifications/EinsteinRiddle)                                                  | Isaac DeFrain, Giuliano Losa                        |          |             |         |     ✔     |    ✔     |
 | [Asynchronous Byzantine Consensus](specifications/aba-asyn-byz)                                     | Thanh Hai Tran, Igor Konnov, Josef Widder           |          |             |         |     ✔     |          |
 | [Folklore Reliable Broadcast](specifications/bcastFolklore)                                         | Thanh Hai Tran, Igor Konnov, Josef Widder           |          |             |         |     ✔     |          |
 | [The Bosco Byzantine Consensus Algorithm](specifications/bosco)                                     | Thanh Hai Tran, Igor Konnov, Josef Widder           |          |             |         |     ✔     |          |
@@ -85,10 +85,10 @@ Here is a list of specs included in this repository, with links to the relevant 
 | [Chameneos, a Concurrency Game](specifications/Chameneos)                                           | Mariusz Ryndzionek                                  |          |             |         |     ✔     |          |
 | [PCR Testing for Snippets of DNA](specifications/glowingRaccoon)                                    | Martin Harrison                                     |          |             |         |     ✔     |          |
 | [RFC 3506: Voucher Transaction System](specifications/byihive)                                      | Santhosh Raju, Cherry G. Mathew, Fransisca Andriani |          |             |         |     ✔     |          |
-| [TLA⁺ Level Checking](specifications/LevelChecking)                                                 | Leslie Lamport                                      |          |             |         |           |          |
-| [Condition-Based Consensus](specifications/cbc_max)                                                 | Thanh Hai Tran, Igor Konnov, Josef Widder           |          |             |         |           |          |
 | [Yo-Yo Leader Election](specifications/YoYo)                                                        | Ludovic Yvoz, Stephan Merz                          |          |             |         |      ✔    |          |
 | [TCP as defined in RFC 9293](specifications/tcp)                                                    | Markus Kuppe                                        |          |             |         |      ✔    |          |
+| [TLA⁺ Level Checking](specifications/LevelChecking)                                                 | Leslie Lamport                                      |          |             |         |           |          |
+| [Condition-Based Consensus](specifications/cbc_max)                                                 | Thanh Hai Tran, Igor Konnov, Josef Widder           |          |             |         |           |          |
 
 ## Examples Elsewhere
 Here is a list of specs stored in locations outside this repository, including submodules.

--- a/manifest-schema.json
+++ b/manifest-schema.json
@@ -61,7 +61,7 @@
                       "mode": {
                         "oneOf": [
                           {
-                            "enum": ["exhaustive search", "generate"]
+                            "enum": ["exhaustive search", "generate", "symbolic"]
                           },
                           {
                             "type": "object",

--- a/manifest.json
+++ b/manifest.json
@@ -454,9 +454,9 @@
           "models": [
             {
               "path": "specifications/EinsteinRiddle/Einstein.cfg",
-              "runtime": "unknown",
-              "size": "large",
-              "mode": "exhaustive search",
+              "runtime": "00:00:01",
+              "size": "small",
+              "mode": "symbolic",
               "features": [],
               "result": "safety failure"
             }

--- a/specifications/EinsteinRiddle/Einstein.tla
+++ b/specifications/EinsteinRiddle/Einstein.tla
@@ -38,7 +38,7 @@
 (* Instructions to run `^Apalache^' appear at the end of the file.               *)
 (*********************************************************************************)
 
-EXTENDS Naturals, FiniteSets
+EXTENDS Naturals, FiniteSets, Apalache
 
 House == 1..5
 
@@ -46,13 +46,17 @@ House == 1..5
 \* would be evaluated faster.  However, TLC!Permutations equals a
 \* set of records whereas Permutation below equals a set of tuples/
 \* sequences.  Also, Permutation expects Cardinality(S) = 5.
-Permutation(S) ==
-    { p \in [ House -> S ] :
-        /\ p[2] \in S \ {p[1]}
-        /\ p[3] \in S \ {p[1], p[2]}
-        /\ p[4] \in S \ {p[1], p[2], p[3]}
-        /\ p[5] \in S \ {p[1], p[2], p[3], p[4]} }
-                
+\* @type: Set(Str) => Set(Seq(Str));
+Permutation(S) == {
+  FunAsSeq(p, 5, 5) : p \in {
+    p \in [ House -> S ] :
+      /\ p[2] \in S \ {p[1]}
+      /\ p[3] \in S \ {p[1], p[2]}
+      /\ p[4] \in S \ {p[1], p[2], p[3]}
+      /\ p[5] \in S \ {p[1], p[2], p[3], p[4]}
+    }
+  }
+
 \* In most specs, the following parameterization would be defined as
 \* constants.  Given that Einstein's riddle has only this
 \* parameterization, the constants are replaced with constant-level
@@ -65,15 +69,15 @@ PETS == Permutation({ "bird", "cat", "dog", "fish", "horse" })
 CIGARS == Permutation({ "blend", "bm", "dh", "pm", "prince" })
 
 VARIABLES
-    \* @type: Int -> Str;
+    \* @type: Seq(Str);
     nationality,    \* tuple of nationalities
-    \* @type: Int -> Str;
+    \* @type: Seq(Str);
     colors,         \* tuple of house colors
-    \* @type: Int -> Str;
+    \* @type: Seq(Str);
     pets,           \* tuple of pets
-    \* @type: Int -> Str;
+    \* @type: Seq(Str);
     cigars,         \* tuple of cigars
-    \* @type: Int -> Str;
+    \* @type: Seq(Str);
     drinks          \* tuple of drinks
 
 ------------------------------------------------------------
@@ -136,7 +140,7 @@ Init ==
 
 \* Apalache cannot infer the type of `vars' because it could be a sequence or a tuple.
 \* So we explicitely tell Apalache that it is a sequence by adding the following annotation:
-\* @type: Seq(Int -> Str);
+\* @type: Seq(Seq(Str));
 vars == <<nationality, colors, cigars, pets, drinks>>
 
 Next ==


### PR DESCRIPTION
This adds Apalache to the CI along with support for using it to check models marked as using the symbolic model-checking mode. Since this requires an extra parameter to be added to a number of scripts, this is a breaking change.

@konnov as FYI