### PR TITLE
Use macOS runner, minor script debug output fixes

### DIFF
--- a/.github/scripts/tla_utils.py
+++ b/.github/scripts/tla_utils.py
@@ -52,8 +52,8 @@ def write_json(data, path):
 
 def parse_module(examples_root, parser, path):
     """
-    Parses a .tla file; returns the parse tree along with whether a parse
-    error was detected.
+    Parses a .tla file with tree-sitter; returns the parse tree along with
+    whether a parse error was detected.
     """
     module_text = None
     path = from_cwd(examples_root, path)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macOS not used; see https://github.com/tlaplus/Examples/issues/119
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         unicode: [true, false]
       fail-fast: false
     env:


### PR DESCRIPTION
Print out TLC command line call in smoke testing script and decode TLC output as UTF-8 if necessary.
Ref #119