### PR TITLE
Add spec of the Disruptor concurrency library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Here is a list of specs included in this repository, with links to the relevant 
 | [TLA⁺ Level Checking](specifications/LevelChecking)                                                 | Leslie Lamport                                      |          |             |         |           |          |
 | [Condition-Based Consensus](specifications/cbc_max)                                                 | Thanh Hai Tran, Igor Konnov, Josef Widder           |          |             |         |           |          |
 | [Buffered Random Access File](specifications/braf)                                                  | Calvin Loncaric                                     |          |             |         |     ✔     |          |
+| [Disruptor](specifications/Disruptor)                                                               | Nicholas Schultz-Møller                             |          |             |         |     ✔     |          |
 
 ## Examples Elsewhere
 Here is a list of specs stored in locations outside this repository, including submodules.

--- a/manifest.json
+++ b/manifest.json
@@ -458,7 +458,9 @@
               "runtime": "00:00:10",
               "size": "small",
               "mode": "exhaustive search",
-              "features": [],
+              "features": [
+                "ignore deadlock"
+              ],
               "result": "success",
               "distinctStates": 112929,
               "totalStates": 406505,
@@ -470,7 +472,8 @@
               "size": "small",
               "mode": "exhaustive search",
               "features": [
-                "liveness"
+                "liveness",
+                "ignore deadlock"
               ],
               "result": "success",
               "distinctStates": 14365,
@@ -491,7 +494,8 @@
               "size": "small",
               "mode": "exhaustive search",
               "features": [
-                "liveness"
+                "liveness",
+                "ignore deadlock"
               ],
               "result": "success",
               "distinctStates": 8153,

--- a/manifest.json
+++ b/manifest.json
@@ -436,6 +436,80 @@
       ]
     },
     {
+      "path": "specifications/Disruptor",
+      "title": "Disruptor",
+      "description": "Models single and multi producer scenarios of the Disruptor library and checks for data races.",
+      "sources": [
+        "https://github.com/nicholassm/disruptor-rs"
+      ],
+      "authors": [
+        "Nicholas Schultz-Møller"
+      ],
+      "tags": [],
+      "modules": [
+        {
+          "path": "specifications/Disruptor/Disruptor_MPMC.tla",
+          "communityDependencies": [],
+          "tlaLanguageVersion": 2,
+          "features": [],
+          "models": [
+            {
+              "path": "specifications/Disruptor/Disruptor_MPMC.cfg",
+              "runtime": "00:00:10",
+              "size": "small",
+              "mode": "exhaustive search",
+              "features": [],
+              "result": "success",
+              "distinctStates": 112929,
+              "totalStates": 406505,
+              "stateDepth": 81
+            },
+            {
+              "path": "specifications/Disruptor/Disruptor_MPMC_liveliness.cfg",
+              "runtime": "00:00:10",
+              "size": "small",
+              "mode": "exhaustive search",
+              "features": [
+                "liveness"
+              ],
+              "result": "success",
+              "distinctStates": 14365,
+              "totalStates": 42101,
+              "stateDepth": 61
+            }
+          ]
+        },
+        {
+          "path": "specifications/Disruptor/Disruptor_SPMC.tla",
+          "communityDependencies": [],
+          "tlaLanguageVersion": 2,
+          "features": [],
+          "models": [
+            {
+              "path": "specifications/Disruptor/Disruptor_SPMC.cfg",
+              "runtime": "00:00:10",
+              "size": "small",
+              "mode": "exhaustive search",
+              "features": [
+                "liveness"
+              ],
+              "result": "success",
+              "distinctStates": 8153,
+              "totalStates": 26481,
+              "stateDepth": 81
+            }
+          ]
+        },
+        {
+          "path": "specifications/Disruptor/RingBuffer.tla",
+          "communityDependencies": [],
+          "tlaLanguageVersion": 2,
+          "features": [],
+          "models": []
+        }
+      ]
+    },
+    {
       "path": "specifications/EinsteinRiddle",
       "title": "Einstein's Riddle",
       "description": "Five houses, five people, various facts, who lives in what house?",

--- a/specifications/Disruptor/Disruptor_MPMC.cfg
+++ b/specifications/Disruptor/Disruptor_MPMC.cfg
@@ -2,9 +2,9 @@ SPECIFICATION
     Spec
 
 CONSTANTS
+    MaxPublished = 10
     Writers = { w1, w2 }
     Readers = { r1, r2, r3 }
-    MaxPublished = 10
     Size = 4
     NULL = NULL
 

--- a/specifications/Disruptor/Disruptor_MPMC.cfg
+++ b/specifications/Disruptor/Disruptor_MPMC.cfg
@@ -2,12 +2,15 @@ SPECIFICATION
     Spec
 
 CONSTANTS
-    Writers = { w1 w2 }
-    Readers = { r1 r2 r3 }
+    Writers = { w1, w2 }
+    Readers = { r1, r2, r3 }
     MaxPublished = 10
     Size = 4
     NULL = NULL
 
 INVARIANTS
-    TypeOK
+    TypeOk
     NoDataRaces
+
+CHECK_DEADLOCK
+    FALSE

--- a/specifications/Disruptor/Disruptor_MPMC.cfg
+++ b/specifications/Disruptor/Disruptor_MPMC.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION
+    Spec
+
+CONSTANTS
+    Writers = { w1 w2 }
+    Readers = { r1 r2 r3 }
+    MaxPublished = 10
+    Size = 4
+    NULL = NULL
+
+INVARIANTS
+    TypeOK
+    NoDataRaces

--- a/specifications/Disruptor/Disruptor_MPMC.tla
+++ b/specifications/Disruptor/Disruptor_MPMC.tla
@@ -1,0 +1,185 @@
+--------------------------- MODULE Disruptor_MPMC ---------------------------
+(***************************************************************************)
+(*  Models a Multi Producer, Multi Consumer Disruptor (MPMC).              *)
+(* The model verifies that no data races occur between the publishers      *)
+(* and consumers and that all consumers eventually read all published      *)
+(* values.                                                                 *)
+(***************************************************************************)
+
+EXTENDS Naturals, Integers, FiniteSets, Sequences
+
+CONSTANTS
+  Writers,          (* Writer/publisher thread ids.    *)
+  Readers,          (* Reader/consumer  thread ids.    *)
+  MaxPublished,     (* Max number of published events. *)
+  Size,             (* Ringbuffer size.                *)
+  NULL
+
+VARIABLES
+  ringbuffer,
+  next_sequence,    (* Shared counter for claiming a sequence for a Writer. *)
+  claimed_sequence, (* Claimed sequence by each Writer.                     *)
+  published,        (* Encodes whether each slot is published.              *)
+  read,             (* Read Cursors. One per Reader.                        *)
+  consumed,         (* Sequence of all read events by the Reader.           *)
+  pc                (* Program Counter of each Writer/Reader.               *)
+
+vars == <<
+  ringbuffer,
+  next_sequence,
+  claimed_sequence,
+  published,
+  read,
+  consumed,
+  pc
+>>
+
+(***************************************************************************)
+(* Each publisher/consumer can be in one of two states:                    *)
+(* 1. Accessing a slot in the Disruptor or                                 *)
+(* 2. Advancing to the next slot.                                          *)
+(***************************************************************************)
+Access  == "Access"
+Advance == "Advance"
+
+Transition(t, from, to) ==
+  /\ pc[t] = from
+  /\ pc'   = [ pc EXCEPT ![t] = to ]
+
+Buffer == INSTANCE RingBuffer
+
+Xor(A, B) == A = ~B
+
+Range(f) ==
+  { f[x] : x \in DOMAIN(f) }
+
+MinReadSequence ==
+  CHOOSE min \in Range(read) : \A r \in Readers : min <= read[r]
+
+(***************************************************************************)
+(* Encode whether an index is published by tracking if the slot was        *)
+(* published in an even or odd index. This works because publishers        *)
+(* cannot overtake consumers.                                              *)
+(***************************************************************************)
+IsPublished(sequence) ==
+  LET
+    index   == Buffer!IndexOf(sequence)
+    \* Round number starts at 0.
+    round   == sequence \div Size
+    is_even == round % 2 = 0
+  IN
+    \* published[index] is true if published in an even round otherwise false
+    \* as it was published in an odd round number.
+    published[index] = is_even
+
+Publish(sequence) ==
+  LET index == Buffer!IndexOf(sequence)
+  \* Flip whether we're at an even or odd round.
+  IN  published' = [ published EXCEPT ![index] = Xor(TRUE, @) ]
+
+(***************************************************************************)
+(* Publisher Actions:                                                      *)
+(***************************************************************************)
+
+BeginWrite(writer) ==
+  LET
+    seq      == next_sequence
+    index    == Buffer!IndexOf(seq)
+    min_read == MinReadSequence
+  IN
+    \* Are we clear of all consumers? (Potentially a full cycle behind).
+    /\ min_read >= seq - Size
+    /\ seq < MaxPublished
+    /\ claimed_sequence' = [ claimed_sequence EXCEPT ![writer] = seq ]
+    /\ next_sequence'    = seq + 1
+    /\ Transition(writer, Access, Advance)
+    /\ Buffer!Write(index, writer, seq)
+    /\ UNCHANGED << consumed, published, read >>
+
+EndWrite(writer) ==
+  LET
+    seq   == claimed_sequence[writer]
+    index == Buffer!IndexOf(seq)
+  IN
+    /\ Transition(writer, Advance, Access)
+    /\ Buffer!EndWrite(index, writer)
+    /\ Publish(seq)
+    /\ UNCHANGED << claimed_sequence, next_sequence, consumed, read >>
+
+(***************************************************************************)
+(* Consumer Actions:                                                       *)
+(***************************************************************************)
+
+BeginRead(reader) ==
+  LET
+    next  == read[reader] + 1
+    index == Buffer!IndexOf(next)
+  IN
+    /\ IsPublished(next)
+    /\ Transition(reader, Access, Advance)
+    /\ Buffer!BeginRead(index, reader)
+    \* Track what we read from the ringbuffer.
+    /\ consumed' = [ consumed EXCEPT ![reader] = Append(@, Buffer!Read(index)) ]
+    /\ UNCHANGED << claimed_sequence, next_sequence, published, read >>
+
+EndRead(reader) ==
+  LET
+    next  == read[reader] + 1
+    index == Buffer!IndexOf(next)
+  IN
+    /\ Transition(reader, Advance, Access)
+    /\ Buffer!EndRead(index, reader)
+    /\ read' = [ read EXCEPT ![reader] = next ]
+    /\ UNCHANGED << claimed_sequence, next_sequence, consumed, published >>
+
+(***************************************************************************)
+(* Spec:                                                                   *)
+(***************************************************************************)
+
+Init ==
+  /\ Buffer!Init
+  /\ next_sequence    = 0
+  /\ claimed_sequence = [ w \in Writers                |-> -1     ]
+  /\ published        = [ i \in 0..Size                |-> FALSE  ]
+  /\ read             = [ r \in Readers                |-> -1     ]
+  /\ consumed         = [ r \in Readers                |-> << >>  ]
+  /\ pc               = [ a \in Writers \union Readers |-> Access ]
+
+Next ==
+  \/ \E w \in Writers : BeginWrite(w)
+  \/ \E w \in Writers : EndWrite(w)
+  \/ \E r \in Readers : BeginRead(r)
+  \/ \E r \in Readers : EndRead(r)
+
+Fairness ==
+  /\ \A w \in Writers : WF_vars(BeginWrite(w))
+  /\ \A w \in Writers : WF_vars(EndWrite(w))
+  /\ \A r \in Readers : WF_vars(BeginRead(r))
+  /\ \A r \in Readers : WF_vars(EndRead(r))
+
+Spec ==
+  Init /\ [][Next]_vars /\ Fairness
+
+(***************************************************************************)
+(* Invariants:                                                             *)
+(***************************************************************************)
+
+NoDataRaces == Buffer!NoDataRaces
+
+TypeOk ==
+  /\ Buffer!TypeOk
+  /\ next_sequence    \in Nat
+  /\ claimed_sequence \in [ Writers                -> Int                 ]
+  /\ published        \in [ 0..Size                -> { TRUE, FALSE }     ]
+  /\ read             \in [ Readers                -> Int                 ]
+  /\ consumed         \in [ Readers                -> Seq(Nat)            ]
+  /\ pc               \in [ Writers \union Readers -> { Access, Advance } ]
+
+(***************************************************************************)
+(* Properties:                                                             *)
+(***************************************************************************)
+
+Liveliness ==
+  <>[] (\A r \in Readers : consumed[r] = [i \in 1..MaxPublished |-> i - 1])
+
+=============================================================================

--- a/specifications/Disruptor/Disruptor_MPMC.tla
+++ b/specifications/Disruptor/Disruptor_MPMC.tla
@@ -20,6 +20,8 @@ CONSTANTS
   Size,             (* Ringbuffer size.                                     *)
   NULL
 
+ASSUME Writers /= {}
+ASSUME Readers /= {}
 ASSUME Size \in Nat \ {0}
 
 VARIABLES

--- a/specifications/Disruptor/Disruptor_MPMC.tla
+++ b/specifications/Disruptor/Disruptor_MPMC.tla
@@ -1,5 +1,5 @@
 --------------------------- MODULE Disruptor_MPMC --------------------------
-***************************************************************************)
+(***************************************************************************)
 (* Models a Multi Producer, Multi Consumer Disruptor (MPMC).               *)
 (*                                                                         *)
 (* The producers publish their claimed sequence number as value into       *)

--- a/specifications/Disruptor/Disruptor_MPMC.tla
+++ b/specifications/Disruptor/Disruptor_MPMC.tla
@@ -1,4 +1,4 @@
---------------------------- MODULE Disruptor_MPMC ---------------------------
+--------------------------- MODULE Disruptor_MPMC --------------------------
 (***************************************************************************)
 (*  Models a Multi Producer, Multi Consumer Disruptor (MPMC).              *)
 (* The model verifies that no data races occur between the publishers      *)
@@ -6,7 +6,7 @@
 (* values.                                                                 *)
 (***************************************************************************)
 
-EXTENDS Naturals, Integers, FiniteSets, Sequences
+EXTENDS Integers, FiniteSets, Sequences
 
 CONSTANTS
   Writers,          (* Writer/publisher thread ids.    *)
@@ -14,6 +14,8 @@ CONSTANTS
   MaxPublished,     (* Max number of published events. *)
   Size,             (* Ringbuffer size.                *)
   NULL
+
+ASSUME Size \in Nat \ {0}
 
 VARIABLES
   ringbuffer,
@@ -46,7 +48,7 @@ Transition(t, from, to) ==
   /\ pc[t] = from
   /\ pc'   = [ pc EXCEPT ![t] = to ]
 
-Buffer == INSTANCE RingBuffer
+Buffer == INSTANCE RingBuffer WITH Values <- Int
 
 Xor(A, B) == A = ~B
 

--- a/specifications/Disruptor/Disruptor_MPMC_liveliness.cfg
+++ b/specifications/Disruptor/Disruptor_MPMC_liveliness.cfg
@@ -2,15 +2,18 @@ SPECIFICATION
     Spec
 
 CONSTANTS
-    Writers = { w1 w2 }
-    Readers = { r1 r2 }
+    Writers = { w1, w2 }
+    Readers = { r1, r2 }
     MaxPublished = 10
     Size = 4
     NULL = NULL
 
 INVARIANTS
-    TypeOK
+    TypeOk
     NoDataRaces
 
 PROPERTIES
     Liveliness
+
+CHECK_DEADLOCK
+    FALSE

--- a/specifications/Disruptor/Disruptor_MPMC_liveliness.cfg
+++ b/specifications/Disruptor/Disruptor_MPMC_liveliness.cfg
@@ -2,9 +2,9 @@ SPECIFICATION
     Spec
 
 CONSTANTS
+    MaxPublished = 10
     Writers = { w1, w2 }
     Readers = { r1, r2 }
-    MaxPublished = 10
     Size = 4
     NULL = NULL
 

--- a/specifications/Disruptor/Disruptor_MPMC_liveliness.cfg
+++ b/specifications/Disruptor/Disruptor_MPMC_liveliness.cfg
@@ -1,0 +1,16 @@
+SPECIFICATION
+    Spec
+
+CONSTANTS
+    Writers = { w1 w2 }
+    Readers = { r1 r2 }
+    MaxPublished = 10
+    Size = 4
+    NULL = NULL
+
+INVARIANTS
+    TypeOK
+    NoDataRaces
+
+PROPERTIES
+    Liveliness

--- a/specifications/Disruptor/Disruptor_SPMC.cfg
+++ b/specifications/Disruptor/Disruptor_SPMC.cfg
@@ -6,7 +6,7 @@ CONSTANTS
     Readers = { r1 r2 r3 }
     MaxPublished = 10
     Size = 4
-    NULL = [ model value ]
+    NULL = NULL
 
 INVARIANTS
     TypeOK

--- a/specifications/Disruptor/Disruptor_SPMC.cfg
+++ b/specifications/Disruptor/Disruptor_SPMC.cfg
@@ -2,9 +2,9 @@ SPECIFICATION
     Spec
 
 CONSTANTS
+    MaxPublished = 10
     Writers = { w }
     Readers = { r1, r2, r3 }
-    MaxPublished = 10
     Size = 4
     NULL = NULL
 

--- a/specifications/Disruptor/Disruptor_SPMC.cfg
+++ b/specifications/Disruptor/Disruptor_SPMC.cfg
@@ -1,0 +1,16 @@
+SPECIFICATION
+    Spec
+
+CONSTANTS
+    Writers = { w }
+    Readers = { r1 r2 r3 }
+    MaxPublished = 10
+    Size = 4
+    NULL = [ model value ]
+
+INVARIANTS
+    TypeOK
+    NoDataRaces
+
+PROPERTIES
+    Liveliness

--- a/specifications/Disruptor/Disruptor_SPMC.cfg
+++ b/specifications/Disruptor/Disruptor_SPMC.cfg
@@ -3,14 +3,17 @@ SPECIFICATION
 
 CONSTANTS
     Writers = { w }
-    Readers = { r1 r2 r3 }
+    Readers = { r1, r2, r3 }
     MaxPublished = 10
     Size = 4
     NULL = NULL
 
 INVARIANTS
-    TypeOK
+    TypeOk
     NoDataRaces
 
 PROPERTIES
     Liveliness
+
+CHECK_DEADLOCK
+    FALSE

--- a/specifications/Disruptor/Disruptor_SPMC.tla
+++ b/specifications/Disruptor/Disruptor_SPMC.tla
@@ -22,6 +22,8 @@ CONSTANTS
   Size,         (* Ringbuffer size.                                  *)
   NULL
 
+ASSUME Writers /= {}
+ASSUME Readers /= {}
 ASSUME Size \in Nat \ {0}
 
 VARIABLES

--- a/specifications/Disruptor/Disruptor_SPMC.tla
+++ b/specifications/Disruptor/Disruptor_SPMC.tla
@@ -1,0 +1,155 @@
+----------------------------- MODULE Disruptor_SPMC -------------------------
+(***************************************************************************)
+(* Models a Single Producer, Multi Consumer Disruptor (SPMC).              *)
+(*                                                                         *)
+(* The model verifies that no data races occur between the publisher       *)
+(* and consumers and that all consumers eventually read all published      *)
+(* values.                                                                 *)
+(*                                                                         *)
+(* To see a data race, try and run the model with two publishers.          *)
+(***************************************************************************)
+
+EXTENDS Naturals, Integers, FiniteSets, Sequences
+
+CONSTANTS
+  Writers,      (* Writer/publisher thread ids.    *)
+  Readers,      (* Reader/consumer  thread ids.    *)
+  MaxPublished, (* Max number of published events. *)
+  Size,         (* Ringbuffer size.                *)
+  NULL
+
+VARIABLES
+  ringbuffer,
+  published,    (* Publisher Cursor.                           *)
+  read,         (* Read Cursors. One per consumer.             *)
+  consumed,     (* Sequence of all read events by the Readers. *)
+  pc            (* Program Counter of each Writer/Reader.      *)
+
+vars == <<
+  ringbuffer,
+  published,
+  read,
+  consumed,
+  pc
+>>
+
+(***************************************************************************)
+(* Each publisher/consumer can be in one of two states:                    *)
+(* 1. Accessing a slot in the Disruptor or                                 *)
+(* 2. Advancing to the next slot.                                          *)
+(***************************************************************************)
+Access  == "Access"
+Advance == "Advance"
+
+Transition(t, from, to) ==
+  /\ pc[t] = from
+  /\ pc'   = [ pc EXCEPT ![t] = to ]
+
+Buffer  == INSTANCE RingBuffer
+
+Range(f) ==
+  { f[x] : x \in DOMAIN(f) }
+
+MinReadSequence ==
+  CHOOSE min \in Range(read) : \A r \in Readers : min <= read[r]
+
+(***************************************************************************)
+(* Publisher Actions:                                                      *)
+(***************************************************************************)
+
+BeginWrite(writer) ==
+  LET
+    next     == published + 1
+    index    == Buffer!IndexOf(next)
+    min_read == MinReadSequence
+  IN
+    \* Are we clear of all consumers? (Potentially a full cycle behind).
+    /\ min_read >= next - Size
+    /\ next < MaxPublished
+    /\ Transition(writer, Access, Advance)
+    /\ Buffer!Write(index, writer, next)
+    /\ UNCHANGED << consumed, published, read >>
+
+EndWrite(writer) ==
+  LET
+    next  == published + 1
+    index == Buffer!IndexOf(next)
+  IN
+    /\ Transition(writer, Advance, Access)
+    /\ Buffer!EndWrite(index, writer)
+    /\ published' = next
+    /\ UNCHANGED << consumed, read >>
+
+(***************************************************************************)
+(* Consumer Actions:                                                       *)
+(***************************************************************************)
+
+BeginRead(reader) ==
+  LET
+    next  == read[reader] + 1
+    index == Buffer!IndexOf(next)
+  IN
+    /\ published >= next
+    /\ Transition(reader, Access, Advance)
+    /\ Buffer!BeginRead(index, reader)
+    \* Track what we read from the ringbuffer.
+    /\ consumed' = [ consumed EXCEPT ![reader] = Append(@, Buffer!Read(index)) ]
+    /\ UNCHANGED << published, read >>
+
+EndRead(reader) ==
+  LET
+    next  == read[reader] + 1
+    index == Buffer!IndexOf(next)
+  IN
+    /\ Transition(reader, Advance, Access)
+    /\ Buffer!EndRead(index, reader)
+    /\ read' = [ read EXCEPT ![reader] = next ]
+    /\ UNCHANGED << consumed, published >>
+
+(***************************************************************************)
+(* Spec:                                                                   *)
+(***************************************************************************)
+
+Init ==
+  /\ Buffer!Init
+  /\ published = -1
+  /\ read      = [ r \in Readers                |-> -1     ]
+  /\ consumed  = [ r \in Readers                |-> << >>  ]
+  /\ pc        = [ a \in Writers \union Readers |-> Access ]
+
+Next ==
+  \/ \E w \in Writers : BeginWrite(w)
+  \/ \E w \in Writers : EndWrite(w)
+  \/ \E r \in Readers : BeginRead(r)
+  \/ \E r \in Readers : EndRead(r)
+
+Fairness ==
+  /\ \A w \in Writers : WF_vars(BeginWrite(w))
+  /\ \A w \in Writers : WF_vars(EndWrite(w))
+  /\ \A r \in Readers : WF_vars(BeginRead(r))
+  /\ \A r \in Readers : WF_vars(EndRead(r))
+
+Spec ==
+  Init /\ [][Next]_vars /\ Fairness
+
+(***************************************************************************)
+(* Invariants:                                                             *)
+(***************************************************************************)
+
+TypeOk ==
+  /\ Buffer!TypeOk
+  /\ published \in Int
+  /\ read      \in [ Readers                -> Int                 ]
+  /\ consumed  \in [ Readers                -> Seq(Nat)            ]
+  /\ pc        \in [ Writers \union Readers -> { Access, Advance } ]
+
+NoDataRaces == Buffer!NoDataRaces
+
+(***************************************************************************)
+(* Properties:                                                             *)
+(***************************************************************************)
+
+Liveliness ==
+  <>[] (\A r \in Readers : consumed[r] = [i \in 1..MaxPublished |-> i - 1])
+
+=============================================================================

--- a/specifications/Disruptor/Disruptor_SPMC.tla
+++ b/specifications/Disruptor/Disruptor_SPMC.tla
@@ -1,4 +1,4 @@
------------------------------ MODULE Disruptor_SPMC -------------------------
+----------------------------- MODULE Disruptor_SPMC ------------------------
 (***************************************************************************)
 (* Models a Single Producer, Multi Consumer Disruptor (SPMC).              *)
 (*                                                                         *)
@@ -9,7 +9,7 @@
 (* To see a data race, try and run the model with two publishers.          *)
 (***************************************************************************)
 
-EXTENDS Naturals, Integers, FiniteSets, Sequences
+EXTENDS Integers, FiniteSets, Sequences
 
 CONSTANTS
   Writers,      (* Writer/publisher thread ids.    *)
@@ -17,6 +17,8 @@ CONSTANTS
   MaxPublished, (* Max number of published events. *)
   Size,         (* Ringbuffer size.                *)
   NULL
+
+ASSUME Size \in Nat \ {0}
 
 VARIABLES
   ringbuffer,
@@ -45,7 +47,7 @@ Transition(t, from, to) ==
   /\ pc[t] = from
   /\ pc'   = [ pc EXCEPT ![t] = to ]
 
-Buffer  == INSTANCE RingBuffer
+Buffer == INSTANCE RingBuffer WITH Values <- Int
 
 Range(f) ==
   { f[x] : x \in DOMAIN(f) }

--- a/specifications/Disruptor/README.md
+++ b/specifications/Disruptor/README.md
@@ -1,0 +1,11 @@
+# Disruptor
+
+The Disruptor originates from LMAX Exchange and is a data structure for very low latent communciation between producers and consumer threads using a ring buffer.
+
+The TLA+ models in this folder model an implementation of the Disruptor in Rust.
+See [Github](https://github.com/nicholassm/disruptor-rs) for the Rust implementation and [LMAX's Github page](https://github.com/LMAX-Exchange) for the original Disruptor implemented in Java.
+
+This folder contains two models for verifying the Single Producer Multi Consumer (SPMC) and Multi Producer Multi Consumer (MPMC) scenarios.
+
+The reason for modelling the Disruptor is to verify that there are no data races between producers and consumers which is not trivial to realise.
+

--- a/specifications/Disruptor/RingBuffer.tla
+++ b/specifications/Disruptor/RingBuffer.tla
@@ -22,6 +22,8 @@ CONSTANTS
   NULL
 
 ASSUME Size \in Nat \ {0}
+ASSUME Writers /= {}
+ASSUME Readers /= {}
 ASSUME NULL \notin Values
 
 VARIABLE ringbuffer

--- a/specifications/Disruptor/RingBuffer.tla
+++ b/specifications/Disruptor/RingBuffer.tla
@@ -1,7 +1,7 @@
 ----------------------------- MODULE RingBuffer -----------------------------
 (***************************************************************************)
-(* Models a Ring Buffer where each slot can contain an integer.            *)
-(* Initially all slots contains NULL.                                      *)
+(* Models a RingBuffer where each slot can contain an element from         *)
+(* Values. Initially all slots contains NULL.                              *)
 (*                                                                         *)
 (* Read and write accesses to each slot are tracked to detect data races.  *)
 (* This entails that each write and read of a slot has multiple steps.     *)

--- a/specifications/Disruptor/RingBuffer.tla
+++ b/specifications/Disruptor/RingBuffer.tla
@@ -1,0 +1,83 @@
+----------------------------- MODULE RingBuffer -----------------------------
+(***************************************************************************)
+(* Models a Ring Buffer where each slot can contain an integer.            *)
+(* Initially all slots contains NULL.                                      *)
+(*                                                                         *)
+(* Read and write accesses to each slot are tracked to detect data races.  *)
+(* This entails that each write and read of a slot has multiple steps.     *)
+(*                                                                         *)
+(* All models using the RingBuffer should assert the NoDataRaces invariant *)
+(* that checks against data races between multiple producer threads and    *)
+(* consumer threads.                                                       *)
+(***************************************************************************)
+
+LOCAL INSTANCE Naturals
+LOCAL INSTANCE Integers
+LOCAL INSTANCE FiniteSets
+
+CONSTANTS
+  Size,
+  Readers,
+  Writers,
+  NULL
+
+VARIABLE ringbuffer
+
+LastIndex == Size - 1
+
+(* Initial state of RingBuffer. *)
+Init ==
+  ringbuffer = [
+    slots   |-> [i \in 0 .. LastIndex |-> NULL ],
+    readers |-> [i \in 0 .. LastIndex |-> {}   ],
+    writers |-> [i \in 0 .. LastIndex |-> {}   ]
+  ]
+
+(* The index into the Ring Buffer for a sequence number.*)
+IndexOf(sequence) ==
+  sequence % Size
+
+(***************************************************************************)
+(* Write operations.                                                       *)
+(***************************************************************************)
+
+Write(index, writer, value) ==
+  ringbuffer' = [
+    ringbuffer EXCEPT
+      !.writers[index] = @ \union { writer },
+      !.slots[index]   = value
+  ]
+
+EndWrite(index, writer) ==
+  ringbuffer' = [ ringbuffer EXCEPT !.writers[index] = @ \ { writer } ]
+
+(***************************************************************************)
+(*  Read operations.                                                       *)
+(***************************************************************************)
+
+BeginRead(index, reader) ==
+  ringbuffer' = [ ringbuffer EXCEPT !.readers[index] = @ \union { reader } ]
+
+Read(index) ==
+  ringbuffer.slots[index]
+
+EndRead(index, reader) ==
+  ringbuffer' = [ ringbuffer EXCEPT !.readers[index] = @ \ { reader } ]
+
+(***************************************************************************)
+(* Invariants.                                                             *)
+(***************************************************************************)
+
+TypeOk ==
+  ringbuffer \in [
+    slots:   UNION { [0 .. LastIndex -> Int \union { NULL }] },
+    readers: UNION { [0 .. LastIndex -> SUBSET(Readers)    ] },
+    writers: UNION { [0 .. LastIndex -> SUBSET(Writers)    ] }
+  ]
+
+NoDataRaces ==
+  \A i \in 0 .. LastIndex :
+    /\ ringbuffer.readers[i] = {} \/ ringbuffer.writers[i] = {}
+    /\ Cardinality(ringbuffer.writers[i]) <= 1
+
+=============================================================================


### PR DESCRIPTION
The `Disruptor` is a concurrency library originally developed and open sourced by LMAX Exchange for low latency communication via a ring buffer between producer and consumer threads.

This PR adds a spec of the Disruptor lib and verifies that data races do not occur.