### PR TITLE
Add small improvements to the Disruptor spec.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -494,6 +494,7 @@
               "size": "small",
               "mode": "exhaustive search",
               "features": [
+                "state constraint",
                 "liveness",
                 "ignore deadlock"
               ],

--- a/manifest.json
+++ b/manifest.json
@@ -459,11 +459,12 @@
               "size": "small",
               "mode": "exhaustive search",
               "features": [
+                "state constraint",
                 "ignore deadlock"
               ],
               "result": "success",
               "distinctStates": 112929,
-              "totalStates": 406505,
+              "totalStates": 422781,
               "stateDepth": 81
             },
             {
@@ -472,12 +473,13 @@
               "size": "small",
               "mode": "exhaustive search",
               "features": [
+                "state constraint",
                 "liveness",
                 "ignore deadlock"
               ],
               "result": "success",
               "distinctStates": 14365,
-              "totalStates": 42101,
+              "totalStates": 44581,
               "stateDepth": 61
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -498,9 +498,9 @@
                 "ignore deadlock"
               ],
               "result": "success",
-              "distinctStates": 8153,
-              "totalStates": 26481,
-              "stateDepth": 81
+              "distinctStates": 8496,
+              "totalStates": 28049,
+              "stateDepth": 82
             }
           ]
         },

--- a/specifications/Disruptor/Disruptor_MPMC.cfg
+++ b/specifications/Disruptor/Disruptor_MPMC.cfg
@@ -12,5 +12,8 @@ INVARIANTS
     TypeOk
     NoDataRaces
 
+CONSTRAINT
+  StateConstraint
+
 CHECK_DEADLOCK
     FALSE

--- a/specifications/Disruptor/Disruptor_MPMC.tla
+++ b/specifications/Disruptor/Disruptor_MPMC.tla
@@ -8,7 +8,7 @@
 (*                                                                         *)
 (* The model also verifies that no data races occur between the producers  *)
 (* and consumers and that all consumers eventually read all published      *)
-(* values.                                                                 *)
+(* values (in a Multicast fashion - i.e. all consumers read all events).   *)
 (***************************************************************************)
 
 EXTENDS Integers, FiniteSets, Sequences
@@ -22,7 +22,8 @@ CONSTANTS
 
 ASSUME Writers /= {}
 ASSUME Readers /= {}
-ASSUME Size \in Nat \ {0}
+ASSUME Size         \in Nat \ {0}
+ASSUME MaxPublished \in Nat \ {0}
 
 VARIABLES
   ringbuffer,
@@ -30,8 +31,10 @@ VARIABLES
   claimed_sequence, (* Claimed sequence by each Writer.                     *)
   published,        (* Encodes whether each slot is published.              *)
   read,             (* Read Cursors. One per Reader.                        *)
-  consumed,         (* Sequence of all read events by the Readers.          *)
-  pc                (* Program Counter for each Writer/Reader.              *)
+  pc,               (* Program Counter for each Writer/Reader.              *)
+  consumed          (* Sequence of all read events by the Readers.          *)
+                    (* This is a history variable used for liveliness       *)
+                    (* checking.                                            *)
 
 vars == <<
   ringbuffer,

--- a/specifications/Disruptor/Disruptor_MPMC_liveliness.cfg
+++ b/specifications/Disruptor/Disruptor_MPMC_liveliness.cfg
@@ -15,5 +15,8 @@ INVARIANTS
 PROPERTIES
     Liveliness
 
+CONSTRAINT
+  StateConstraint
+
 CHECK_DEADLOCK
     FALSE

--- a/specifications/Disruptor/Disruptor_SPMC.cfg
+++ b/specifications/Disruptor/Disruptor_SPMC.cfg
@@ -15,5 +15,8 @@ INVARIANTS
 PROPERTIES
     Liveliness
 
+CONSTRAINT
+  StateConstraint
+
 CHECK_DEADLOCK
     FALSE


### PR DESCRIPTION
- Add comment on 'Multicast' behaviour.
- Add ASSUME for MaxPublished constant.
- Add comment on the usage of the 'consumed' variable.
- Remove WF from write actions.
- Remove bounding of model happening in BeginWrite action. Use a State constraint instead. Use suggestion for liveliness property.
- (The last two items are not done yet for the MPMC spec - it's less straight forward to do because of the multiple producers behaviour.)