### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,8 +145,6 @@ jobs:
             specifications/ewd998/EWD998_proof.tla
             ## Regressions?
             specifications/byzpaxos/Consensus.tla
-            specifications/LearnProofs/FindHighest.tla
-            specifications/LoopInvariance/BinarySearch.tla
             specifications/TeachingConcurrency/SimpleRegular.tla
             # Failing; see https://github.com/tlaplus/Examples/issues/67
             specifications/Bakery-Boulangerie/Bakery.tla


### PR DESCRIPTION
Remove FindHighest and BinarySearch from list of skipped proofs.