### PR TITLE
Fix simple regular

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,7 +147,6 @@ jobs:
             specifications/byzpaxos/Consensus.tla
             specifications/LearnProofs/FindHighest.tla
             specifications/LoopInvariance/BinarySearch.tla
-            specifications/TeachingConcurrency/SimpleRegular.tla
             # Failing; see https://github.com/tlaplus/Examples/issues/67
             specifications/Bakery-Boulangerie/Bakery.tla
             specifications/Bakery-Boulangerie/Boulanger.tla

--- a/specifications/TeachingConcurrency/SimpleRegular.tla
+++ b/specifications/TeachingConcurrency/SimpleRegular.tla
@@ -49,7 +49,7 @@
 (* regular registers was proposed by Yuri Abraham in                       *)
 (*                                                                         *)
 (*    On Lamport's "Teaching Concurrency"                                  *)
-(*    Bulletin of EATS (European Association for Theoretical Computer      *)
+(*    Bulletin of EATCS (European Association for Theoretical Computer     *)
 (*      Science) No. 127, February 2019                                    *)
 (*    http://bulletin.eatcs.org/index.php/beatcs/article/view/569          *)
 (***************************************************************************)
@@ -141,9 +141,11 @@ Inv ==  /\ TypeOK
 (* generated with the Toolbox's Decompose Proof command.                   *)
 (***************************************************************************)
 THEOREM Spec => []PCorrect
-<1> USE NAssump
+<1> USE NAssump DEF ProcSet
 <1>1. Init => Inv
-  BY DEF Init, Inv, TypeOK, ProcSet 
+  <2>1. Init => \E i \in 0..(N-1) : pc[i] /= "Done"
+    BY DEF Init
+  <2>. QED  BY <2>1 DEF Init, Inv, TypeOK
 <1>2. Inv /\ [Next]_vars => Inv'
   <2> SUFFICES ASSUME Inv,
                       [Next]_vars

--- a/specifications/TeachingConcurrency/SimpleRegular.tla
+++ b/specifications/TeachingConcurrency/SimpleRegular.tla
@@ -143,7 +143,7 @@ Inv ==  /\ TypeOK
 THEOREM Spec => []PCorrect
 <1> USE NAssump DEF ProcSet
 <1>1. Init => Inv
-  <2>1. Init => \E i \in 0..(N-1) : pc[i] /= "Done"
+  <2>1. Init => 0 \in 0..(N-1) /\ pc[0] /= "Done"
     BY DEF Init
   <2>. QED  BY <2>1 DEF Init, Inv, TypeOK
 <1>2. Inv /\ [Next]_vars => Inv'


### PR DESCRIPTION
The proof of TeachingConcurrency/SimpleRegular.tla should now work with tlapm 1.6.0.