### PR TITLE
Docs: added CONTRIBUTING.md and DEVELOPING.md

### DIFF
--- a/.github/scripts/record_model_state_space.py
+++ b/.github/scripts/record_model_state_space.py
@@ -14,6 +14,7 @@ parser.add_argument('--tools_jar_path', help='Path to the tla2tools.jar file', r
 parser.add_argument('--tlapm_lib_path', help='Path to the TLA+ proof manager module directory; .tla files should be in this directory', required=True)
 parser.add_argument('--community_modules_jar_path', help='Path to the CommunityModules-deps.jar file', required=True)
 parser.add_argument('--manifest_path', help='Path to the tlaplus/examples manifest.json file', required=True)
+parser.add_argument('--enable_assertions', help='Enable Java assertions (pass -enableassertions to JVM)', action='store_true')
 args = parser.parse_args()
 
 logging.basicConfig(level=logging.INFO)
@@ -23,19 +24,24 @@ tlapm_lib_path = normpath(args.tlapm_lib_path)
 community_jar_path = normpath(args.community_modules_jar_path)
 manifest_path = normpath(args.manifest_path)
 examples_root = dirname(manifest_path)
+enable_assertions = args.enable_assertions
 
-def check_model(module_path, model):
-    module_path = tla_utils.from_cwd(examples_root, module_path)
+def check_model(module, model):
+    module_path = tla_utils.from_cwd(examples_root, module['path'])
     model_path = tla_utils.from_cwd(examples_root, model['path'])
     logging.info(model_path)
     hard_timeout_in_seconds = 60
     tlc_result = tla_utils.check_model(
         tools_jar_path,
+        '.',
         module_path,
         model_path,
         tlapm_lib_path,
         community_jar_path,
         model['mode'],
+        module['features'],
+        model['features'],
+        enable_assertions,
         hard_timeout_in_seconds
     )
     match tlc_result:
@@ -66,7 +72,7 @@ def check_model(module_path, model):
 manifest = tla_utils.load_json(manifest_path)
 small_models = sorted(
     [
-        (module['path'], model, tla_utils.parse_timespan(model['runtime']))
+        (module, model, tla_utils.parse_timespan(model['runtime']))
         for spec in manifest['specifications']
         for module in spec['modules']
         for model in module['models']
@@ -84,8 +90,8 @@ small_models = sorted(
     reverse=True
 )
 
-for module_path, model, _ in small_models:
-    success = check_model(module_path, model)
+for module, model, _ in small_models:
+    success = check_model(module, model)
     if not success:
         exit(1)
     tla_utils.write_json(manifest, manifest_path)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing a Spec
+
+Do you have a TLA⁺ specification you'd like to share with the community?
+Your contribution would be greatly appreciated!
+In addition to serving as an example, your spec will function as a powerful real-world test case for TLA⁺ language tooling.
+The spec will also enjoy basic maintenance over the years, ensuring it remains functional & relevant as new features are added to TLA⁺ and its tools.
+
+To ensure a high bar of quality, all specs in this repo are subject to automated continuous integration tests.
+This means the spec contribution process has some amount of configuration & overhead, which can occasionally bring frustration.
+If you are willing to push through this yourself that is greatly appreciated, but if it becomes an undue obstacle you can also add your spec directory to the [`.ciignore`](.ciignore) file to exclude your spec from validation; maintainers can then integrate it into the CI system at a later date.
+
+Licensing your contributed specs under MIT is most appreciated, for consistency; however, other compatible permissive licenses are accepted.
+
+## Basic Contribution Steps
+
+1. Fork this repository and create a new directory under `specifications` with the name of your spec.
+1. Place all TLA⁺ files in the directory, along with their `.cfg` model files.
+1. You are encouraged to include at least one model that completes execution in less than 10 seconds, and (if possible) a model that fails in an interesting way - for example illustrating a system design you previously attempted that was found unsound by TLC.
+1. Ensure the name of each `.cfg` file matches the `.tla` file it models, or has its name as a prefix; for example `SpecName.tla` can have the models `SpecName.cfg` and `SpecNameLiveness.cfg`.
+   This makes it clear which model files are associated with which spec.
+1. Include a `README.md` in the spec directory explaining the significance of the spec with links to any relevant websites or publications, or integrate this info as comments in the spec itself.
+
+At this point, you have the option of adding your spec directory to the [`.ciignore`](.ciignore) file to simply contribute the spec files & exclude it from automated validation.
+Contribution volume is low enough that maintainers will be able to onboard your spec to the validation process eventually.
+However, if you are willing to put in the addition work of onboarding your spec to continuous integration yourself, follow the steps below.
+
+## Adding Spec to Continuous Integration
+
+All specs & models in this repository are subject to many validation checks; for a full listing, see [`DEVELOPING.md`](DEVELOPING.md).
+While many of these checks concern basic properties like whether the spec parses properly and its models do not crash, they also check whether the spec correctly reflects metadata stored about it in [`manifest.json`](manifest.json) and a table in [`README.md`](README.md).
+
+The central file containing metadata about all specs is [`manifest.json`](manifest.json).
+You will need to add an entry to it for your spec & model files.
+This can either be done manually (by looking at existing examples) or largely automated using the instructions below; note that if done manually you are very likely to miss tagging your spec with some feature flags detected & enforced by the CI.
+Before submitted your changes to run in the CI, you can quickly check your [`manifest.json`](manifest.json) against the schema [`manifest-schema.json`](manifest-schema.json) at https://www.jsonschemavalidator.net/.
+Steps:
+
+1. Ensure you have Python 3.11+ installed; open a terminal in the root of this repository
+1. It is considered best practice to create & initialize a Python virtual environment so the required packages are not installed globally; run `python -m venv .` then `source ./bin/activate` on Linux & macOS or `.\Scripts\activate.bat` on Windows (run `deactivate` to exit)
+1. Run `pip install -r .github/scripts/requirements.txt`
+1. Run `python .github/scripts/generate_manifest.py` to auto-generate your spec entry in [`manifest.json`](manifest.json) with as many details as possible
+1. Locate your spec's entry in the [`manifest.json`](manifest.json) file and ensure the following fields are filled out:
+   - Spec title: an appropriate title for your specification
+   - Spec description: a short description of your specification
+   - Spec sources: links relevant to the source of the spec (papers, blog posts, repositories)
+   - Spec authors: a list of people who authored the spec
+   - Spec tags:
+     - `"beginner"` if your spec is appropriate for TLA⁺ newcomers
+   - Model runtime: approximate model runtime on an ordinary workstation, in `"HH:MM:SS"` format
+   - Model size:
+     - `"small"` if the model can be executed in less than 10 seconds
+     - `"medium"` if the model can be executed in less than five minutes
+     - `"large"` if the model takes more than five minutes to execute
+   - Model mode:
+     - `"exhaustive search"` by default
+     - `{"simulate": {"traceCount": N}}` for a simulation model
+     - `"generate"` for model trace generation
+     - `"symbolic"` for models checked using Apalache
+   - Model result:
+     - `"success"` if the model completes successfully
+     - `"assumption failure"` if the model violates an assumption
+     - `"safety failure"` if the model violates an invariant
+     - `"liveness failure"` if the model fails to satisfy a liveness property
+     - `"deadlock failure"` if the model encounters deadlock
+   - (Optional) Model state count info: distinct states, total states, and state depth
+     - These are all individually optional and only valid if your model uses exhaustive search and results in success
+     - Recording these turns your model into a powerful regression test for TLC
+   - Other fields are auto-generated by the script; if you are adding an entry manually, ensure their values are present and correct (see other entries or the [`manifest-schema.json`](manifest-schema.json) file)
+1. Add your spec somewhere in the **topmost** table (not the bottom one, don't get them mixed up!) in [`README.md`](README.md); this must have:
+   - The spec name as a link to the spec's directory, matching the name in the [`manifest.json`](manifest.json)
+   - A comma-separated list of authors, which must also match the list of authors in [`manifest.json`](manifest.json)
+   - A checkmark indicating whether the spec is appropriate for beginners
+     - Checked IFF (if and only if) `beginner` is present in the `tags` field of your spec in [`manifest.json`](manifest.json)
+   - A checkmark indicating whether the spec contains a formal proof
+     - Checked IFF a `proof` tag is present in the `features` field of least one module under your spec in [`manifest.json`](manifest.json)
+   - A checkmark indicating whether the spec contains PlusCal
+     - Checked IFF a `pluscal` tag is present in the `features` field of least one module under your spec in [`manifest.json`](manifest.json)
+   - A checkmark indicating whether the spec contains a TLC-checkable model
+     - Checked IFF `exhaustive search`, `generate`, or `simulate` tags are present in the `mode` field of at least one model under your spec in [`manifest.json`](manifest.json)
+   - A checkmark indicating whether the spec contains an Apalache-checkable model
+     - Checked IFF `symbolic` tag is present in the `mode` field of at least one model under your spec in [`manifest.json`](manifest.json)
+
+At this point you can open a pull request and the CI will run against your spec, alerting you to any details that you missed.
+These scripts can be run locally for a faster development loop; see [`DEVELOPING.md`](DEVELOPING.md) for details.
+

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,137 @@
+# Overview
+
+This document covers three topics:
+1. The role of each CI validation script, how they work, and how to run them locally
+1. Tips for consuming this repo as a test corpus for your own TLA⁺ tooling
+1. Advice for maintaining & extending the CI validation scripts
+
+## The Scripts
+
+All scripts live in the [`.github/scripts`](.github/scripts) directory.
+Here is a brief overview of each script in the order they are run in [the CI](.github/workflows/CI.yml):
+1. [`check_manifest_schema.py`](.github/scripts/check_manifest_schema.py): this uses the [jsonschema](https://pypi.org/project/jsonschema/) python package to validate the contents of the [`manifest.json`](manifest.json) file against its schema, [`manifest-schema.json`](manifest-schema.json).
+1. [`check_manifest_files.py`](.github/scripts/check_manifest_files.py): this ensures the modules & models recorded in [`manifest.json`](manifest.json) concord with the set of modules & models found under the [`specifications`](specifications) directory, while also respecting the exclusion of any specs in the [`.ciignore`](.ciignore) file.
+1. [`check_manifest_features.py`](.github/scripts/check_manifest_features.py`): this uses the [tree-sitter-tlaplus](https://pypi.org/project/tree-sitter-tlaplus/) python package to run queries on all the `.tla` files and ensure their features (`proof`, `pluscal`, `action composition`) are correctly recorded in [`manifest.json`](manifest.json); it also does best-effort regex parsing of all `.cfg` files to ensure their features (`view`, `alias`, etc.) are similarly correctly recorded.
+1. [`check_markdown_table.py`](.github/scripts/check_markdown_table.py): this uses the [mistletoe](https://pypi.org/project/mistletoe/) markdown parser python package to parse [`README.md`](README.md), extract the spec table, then validate its format & contents against [`manifest.json`](manifest.json); before this script was developed the table tended to diverge wildly from the actual content of this repo.
+1. [`unicode_conversion.py`](.github/scripts/unicode_conversion.py): this script uses [tlauc](https://github.com/tlaplus-community/tlauc) to convert each spec into its [Unicode](https://github.com/tlaplus/tlaplus-standard/tree/652a8eb5d5838b9712be3502cb36dbae826d5689/unicode) form to ensure TLA⁺ tooling functions identically on ASCII & Unicode specs.
+   The CI spawns separate runs with and without conversion of specs to Unicode.
+1. [`unicode_number_set_shim.py`](.github/scripts/unicode_number_set_shim.py): since Unicode adoption is not yet fully ratified, Unicode definitions like `ℕ`, `ℤ`, and `ℝ` (as synonyms for `Nat`, `Int`, and `Real` respectively) are not yet included in the standard modules.
+   This script works around that by using the [tree-sitter-tlaplus](https://pypi.org/project/tree-sitter-tlaplus/) python package to rewrite all imports of the `Naturals`, `Integers`, and `Reals` modules to import shim modules instead that define `ℕ`, `ℤ`, and `ℝ`.
+   Once TLA⁺ fully adopts Unicode this (quite hackish) script will no longer be necessary.
+1. [`translate_pluscal.py`](.github/scripts/translate_pluscal.py): this script runs the PlusCal translator on all modules containing PlusCal, to ensure their PlusCal syntax is valid.
+1. [`parse_modules.py`](.github/scripts/parse_modules.py): this script runs the SANY parser against all `.tla` files in the repository to ensure they are syntactically & semantically valid.
+   This can get quite complicated as many modules import specs defined in Apalache, TLAPM, or the community modules.
+1. [`check_small_models.py`](.github/scripts/check_small_models.py): this script runs TLC or Apalache to completion against all models marked as "small", which means they should complete within 30 seconds.
+   The script ensures the models don't crash and that their result is as expected, either success or a specific type of failure.
+   If applicable, the script also checks the size of the state graph against the values recorded in [`manifest.json`](manifest.json).
+1. [`smoke_test_large_models.py`](.github/scripts/smoke_test_large_models.py): not all models in this repository can be run to completion within 30 seconds, so this script runs medium & large models for five seconds before terminating their process - just to ensure they basically function and don't immediately crash.
+1. [`check_proofs.py`](.github/scripts/check_proofs.py): this script runs TLAPM against all modules that contain formal proofs, to ensure the proofs are valid.
+
+There are also a number of utility scripts:
+1. [`generate_manifest.py`](.github/scripts/generate_manifest.py): this can be run by users to automatically find & generate an entry for their new specs in the [`manifest.json`](manifest.json) file.
+   It uses the [tree-sitter-tlaplus](https://pypi.org/project/tree-sitter-tlaplus/) python package to find all required tags and features.
+1. [`tla_utils.py`](.github/scripts/tla_utils.py): not a script by itself, but contains common functions used by all the other scripts.
+1. [`record_model_state_space.py`](.github/scripts/record_model_state_space.py): this script runs all small models that lack state space info, extracts their state space info, and records it in the [`manifest.json`](manifest.json) file; useful if a large number of specs need to have this info recorded in a batch.
+1. [`format_markdown_table.py`](.github/scripts/format_markdown_table.py): this script is intended for use by developers to script formatting updates to the markdown table (add columns, reorder columns, etc.) to avoid the tedium of having to do this by hand.
+
+### Running the Scripts
+
+Here is how to execute these scripts on your local machine, as they would be executed in a CI run; first, download dependencies to the `deps` directory on Linux & macOS:
+```sh
+./.github/scripts/linux-setup.sh .github/scripts deps true
+```
+or Windows:
+```sh
+.\.github\scripts\windows-setup.sh .github\scripts deps true
+```
+Activate your Python virtual environment on Linux & macOS:
+```sh
+source ./bin/activate
+```
+or Windows:
+```sh
+.\Scripts\activate.bat
+```
+Execute your desired scripts as follows; they are provided in individual code blocks for easy copy & paste.
+On Windows you might need to use `\` instead of `/` for path separation, but depending on your terminal these snippets could work as-is.
+Scripts will output a descriptive error message and nonzero exit code on failure.
+Most scripts accept `--skip` and `--only` parameters to skip running on specific files or only run on specific files, which is helpful for quickly testing your changes against the longer-running scripts like `check_small_models.py`.
+Many scripts also accept the `--verbose` flag which will output the full command-line arguments and output of any tools they run.
+```sh
+python .github/scripts/check_manifest_schema.py --manifest_path manifest.json --schema_path manifest-schema.json
+```
+```sh
+python .github/scripts/check_manifest_files.py --manifest_path manifest.json --ci_ignore_path .ciignore
+```
+```sh
+python .github/scripts/check_manifest_features.py --manifest_path manifest.json
+```
+```sh
+python .github/scripts/check_markdown_table.py --manifest_path manifest.json --readme_path README.md
+```
+**WARNING:** the `unicode_conversion.py`, `unicode_number_set_shim.py`, and `translate_pluscal.py` scripts make large numbers of changes to files in your local repository, so be sure to run them on a clean branch where your own changes can't be clobbered and you can easily revert with `git reset --hard HEAD`.
+```sh
+python .github/scripts/unicode_conversion.py --tlauc_path deps/tlauc/tlauc --manifest_path manifest.json
+```
+Delete all the shim files generated by `unicode_number_set_shim.py` with `find . -iname "*_UnicodeShim.tla" -delete`.
+```sh
+python .github/scripts/unicode_number_set_shim.py --manifest_path manifest.json
+```
+```sh
+python .github/scripts/translate_pluscal.py --tools_jar_path deps/tools/tla2tools.jar --manifest_path manifest.json
+```
+```sh
+python .github/scripts/parse_modules.py --tools_jar_path deps/tools/tla2tools.jar --apalache_path deps/apalache --tlapm_lib_path deps/tlapm/library --community_modules_jar_path deps/community/modules.jar --manifest_path manifest.json
+```
+```sh
+python .github/scripts/check_small_models.py --tools_jar_path deps/tools/tla2tools.jar --apalache_path deps/apalache --tlapm_lib_path deps/tlapm/library --community_modules_jar_path deps/community/modules.jar --manifest_path manifest.json
+```
+```sh
+python .github/scripts/smoke_test_large_models.py --tools_jar_path deps/tools/tla2tools.jar --apalache_path deps/apalache --tlapm_lib_path deps/tlapm/library --community_modules_jar_path deps/community/modules.jar --manifest_path manifest.json
+```
+Note: `check_proofs.py` does not run on Windows.
+```sh
+python .github/scripts/check_proofs.py --tlapm_path deps/tlapm --manifest_path manifest.json
+```
+You can also run the non-CI utility scripts as follows:
+```sh
+python .github/scripts/generate_manifest.py --manifest_path manifest.json --ci_ignore_path .ciignore
+```
+```sh
+python .github/scripts/record_model_state_space.py --tools_jar_path deps/tools/tla2tools.jar --tlapm_lib_path deps/tlapm/library --community_modules_jar_path deps/community/modules.jar --manifest_path manifest.json
+```
+Exit your Python virtual environment by running `deactivate`.
+
+## Consuming the Examples
+
+In addition to its teaching value, this repository is an excellent source of real-world nontrivial TLA⁺ specs ideal for use in tests.
+Several TLA⁺ tools already import this repository for testing purposes in their CI:
+- The [TLA⁺ Java Tools](https://github.com/tlaplus/tlaplus)
+- The [TLA⁺ Proof Manager](https://github.com/tlaplus/tlapm)
+- The [TLA⁺ tree-sitter grammar](https://github.com/tlaplus-community/tree-sitter-tlaplus)
+- The [TLA⁺ Unicode converter](https://github.com/tlaplus-community/tlauc)
+
+Here is some advice for consuming this repo in your own project:
+- The most important file to consider is [`manifest.json`](manifest.json); almost all languages have binding libraries for JSON, and you can use it to get a list of spec/module paths along with various features to filter on.
+- Consider using a [release of this repo](https://github.com/tlaplus/Examples/releases) instead of just pulling from the head of the main branch, since the manifest format is occasionally changed and these changes are captured in minor version bumps.
+  Releases with a patch version bump only contain new specs or other non-breaking changes.
+- If using this repo to test your tool requires additional metadata or scripting that could be commonly useful, consider [opening an issue](https://github.com/tlaplus/Examples/issues) explaining your use case; we are always interested in supporting new TLA⁺ tooling development!
+
+## Maintaining & Extending the Scripts
+
+The scripts are almost all written in Python, so updating the scripts will require Python knowledge.
+The scripts do not make use of many fancy language features (other than list comprehensions) so relative newcomers should find them accessible.
+There are a few common occasions where it is necessary to update or extend the scripts:
+1. **Run another tool or validate a new property**: if a TLA⁺ tool becomes prominent enough, it could be added to the set of tools run in the CI of this repo.
+   This would entail writing a new script and adding it to the CI, along with updating the install scripts to pull the new tool.
+   Every script follows the same basic format: parse command-line arguments, get a list of applicable files to check from the manifest, then run the tool against the files.
+   Most of this can be copied & pasted from existing scripts, with some modifications.
+1. **Expose a new feature flag**: while we try to make the manifest data as independent from any specific TLA⁺ tool backend as possible, there are cases where a specific feature flag or command-line argument must be used in only certain cases.
+   For example, at one point TLC required the `-Dtlc2.tool.impl.Tool.cdot=true` flag to be passed to it when processing specs using the `\cdot` action composition operator; this was solved by adding another module-level `action composition` feature tag to the manifest, then passing the feature flag to TLC when that feature tag was present (see [this PR](https://github.com/tlaplus/Examples/pull/156)).
+   This preserved the independence of the manifest from a specific tooling backend.
+   Future developers should endeavor to maintain this independence and, to the extent practical, avoid adding functionality like directly encoding command-line arguments in the manifest.
+1. **Follow tree-sitter API updates**: the scripts make heavy use of [tree-sitter-tlaplus](https://github.com/tlaplus-community/tree-sitter-tlaplus) for querying spec features.
+   The grammar is now largely stable with only occasional bugfixes, so the scripts should not have to update the version they use very often (which is encoded in the [`requirements.txt`](.github/scripts/requirements.txt) file).
+   Still, there may come a time when a tree-sitter-tlaplus bugfix is needed *and* the grammar has updated its version of the underlying [`tree-sitter`](https://pypi.org/project/tree-sitter/) package, meaning the tree-sitter python bindings change or break.
+   This will likely be a difficult fix for those unfamiliar with the tree-sitter API; [this PR](https://github.com/tlaplus/Examples/pull/156) included an update to changed tree-sitter query bindings, as an example.
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,17 @@ It serves as:
 - a collection of case studies in the application of formal specification in TLA<sup>+</sup>
 
 All TLA<sup>+</sup> specs can be found in the [`specifications`](specifications) directory.
-The table below lists all specs and indicates whether a spec is beginner-friendly, includes an additional PlusCal variant `(✔)`, or uses PlusCal exclusively. Additionally, the table specifies which verification tool—[TLC](https://github.com/tlaplus/tlaplus), [Apalache](https://github.com/apalache-mc/apalache), or [TLAPS](https://github.com/tlaplus/tlapm)—can be used to verify each specification.
+To contribute a spec of your own, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+The table below lists all specs and indicates whether a spec is beginner-friendly, includes an additional PlusCal variant `(✔)`, or uses PlusCal exclusively.
+Additionally, the table specifies which verification tool—[TLC](https://github.com/tlaplus/tlaplus), [Apalache](https://github.com/apalache-mc/apalache), or [TLAPS](https://github.com/tlaplus/tlapm)—can be used to verify each specification.
+
+Space contraints limit the information displayed in the table; detailed spec metadata can be found in the [`manifest.json`](manifest.json) file.
+You can search this file for examples exhibiting a number of features, like:
+ - Specs (`.tla` files) including `pluscal`, `proof`, or `action composition` (the `\cdot` operator)
+ - Specs intended for trace generation (`generate`), `simulate`, or checked symbolically with Apalache (`symbolic`)
+ - Models (`.cfg` files) using the `symmetry`, `view`, `alias`, `state constraint`, or `ignore deadlock` features
+ - Models failing in interesting ways, like `deadlock failure`, `safety failure`, `liveness failure`, or `assumption failure`
 
 ## Examples Included Here
 Here is a list of specs included in this repository, with links to the relevant directory and flags for various features:
@@ -134,63 +144,15 @@ Ideally these will be moved into this repo over time.
 | [CRDT](https://github.com/JYwellin/CRDT-TLA)                                                                                      | Specifying and Verifying CRDT Protocols                                                                                                   | Ye Ji, Hengfeng Wei                                                        |          |             |     ✔     |         |          |
 | [Azure Cosmos DB](https://github.com/tlaplus/azure-cosmos-tla)                                                                    | Consistency models provided by Azure Cosmos DB                                                                                            | Dharma Shukla, Ailidani Ailijiang, Murat Demirbas, Markus Kuppe            |          |             |     ✔     |    ✔    |          |
 
+## Contributing a Spec
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for instructions.
+
 ## License
 The repository is under the MIT license and you are encouraged to publish your spec under a similarly-permissive license.
 However, your spec can be included in this repo along with your own license if you wish.
 
 ## Support or Contact
 Do you have any questions or comments?
-Please open an issue or send an email to the [TLA+ group](https://groups.google.com/g/tlaplus).
-
-## Contributing
-Do you have your own case study or TLA<sup>+</sup> specification you'd like to share with the community?
-Follow these instructions:
-1. Fork this repository and create a new directory under `specifications` with the name of your spec
-1. Place all TLA<sup>+</sup> files in the directory, along with their `.cfg` model files
-1. You are encouraged to include at least one model that completes execution in less than 10 seconds, and (if possible) a model that fails in an interesting way - for example illustrating a system design you previously attempted that was found unsound by TLC
-1. Ensure name of each `.cfg` file matches the `.tla` file it models, or has its name as a prefix; for example `SpecName.tla` can have the models `SpecName.cfg` and `SpecNameLiveness.cfg`, etc.
-1. Consider including a `README.md` in the spec directory explaining the significance of the spec with links to any relevant websites or publications, or integrate this info as comments in the spec itself
-1. Add an entry to the table of specs included in this repo, summarizing your spec and its attributes
-
-The [`manifest.json`](manifest.json) file is the source of truth for this table, and is a detailed human- & machine-readable description of the specs & their models.
-Its schema is [`manifest-schema.json`](manifest-schema.json).
-All specs in this repository are subject to CI validation to ensure quality.
-
-## Adding Spec to Continuous Integration
-To combat bitrot, it is important to add your spec and model to the continuous integration system.
-To do this, you'll have to update the [`manifest.json`](manifest.json) file with machine-readable records of your spec files.
-If this process doesn't work for you, you can alternatively modify the [`.ciignore`](.ciignore) file to exclude your spec from validation.
-Modifying the `manifest.json` can be done manually or (recommended) following these directions:
-1. Ensure you have Python 3.11+ installed
-1. It is considered best practice to create & initialize a Python virtual environment to preserve your system package store; run `python -m venv .` then `source ./bin/activate` on Linux & macOS or `.\Scripts\activate.bat` on Windows (run `deactivate` to exit)
-1. Run `pip install -r .github/scripts/requirements.txt`
-1. Run `python .github/scripts/generate_manifest.py`
-1. Locate your spec's entry in the [`manifest.json`](manifest.json) file and ensure the following fields are filled out:
-   - Spec title: an appropriate title for your specification
-   - Spec description: a short description of your specification
-   - Spec sources: links relevant to the source of the spec (papers, blog posts, repositories)
-   - Spec authors: a list of people who authored the spec
-   - Spec tags:
-     - `"beginner"` if your spec is appropriate for TLA<sup>+</sup> newcomers
-   - Model runtime: approximate model runtime on an ordinary workstation, in `"HH:MM:SS"` format
-   - Model size:
-     - `"small"` if the model can be executed in less than 10 seconds
-     - `"medium"` if the model can be executed in less than five minutes
-     - `"large"` if the model takes more than five minutes to execute
-   - Model mode:
-     - `"exhaustive search"` by default
-     - `{"simulate": {"traceCount": N}}` for a simulation model
-     - `"generate"` for model trace generation
-   - Model result:
-     - `"success"` if the model completes successfully
-     - `"assumption failure"` if the model violates an assumption
-     - `"safety failure"` if the model violates an invariant
-     - `"liveness failure"` if the model fails to satisfy a liveness property
-     - `"deadlock failure"` if the model encounters deadlock
-   - (Optional) Model state count info: distinct states, total states, and state depth
-     - These are all individually optional and only valid if your model uses exhaustive search and results in success
-     - Recording these turns your model into a powerful regression test for TLC
-   - Other fields are auto-generated by the script; if you are adding an entry manually, ensure their values are present and correct (see other entries or the [`manifest-schema.json`](manifest-schema.json) file)
-
-Before submitted your changes to run in the CI, you can quickly check your [`manifest.json`](manifest.json) for errors and also check it against [`manifest-schema.json`](manifest-schema.json) at https://www.jsonschemavalidator.net/.
+Please open an issue or send an email to the [TLA⁺ mailing list](https://groups.google.com/g/tlaplus).
 


### PR DESCRIPTION
Changes:
- Add notes to README.md about how to usefully query the manifest.json file for various features (I especially often use this for advanced model file features like ALIAS and such)
- Move contributing instructions from README.md to standalone CONTRIBUTING.md for greater detail; emphasize the possibility of using `.ciignore`
- Document all the CI scripts and how to run them in DEVELOPING.md, along with how to consume this repo in your own project
- Noticed the `record_model_state_space.py` script was broken so I fixed it