### PR TITLE
CI: terminate outdated CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ on:
       - master
   repository_dispatch:
     types: [tlaplus-dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:


### PR DESCRIPTION
If you push changes to a PR before the current CI run is complete, it will be terminated in favor of the new CI run.