### PR TITLE
Manifest: remove path, title, and description fields

### DIFF
--- a/.github/scripts/check_manifest_features.py
+++ b/.github/scripts/check_manifest_features.py
@@ -154,16 +154,10 @@ def check_features(parser, queries, manifest, examples_root):
     Validates every field of the manifest that can be validated.
     """
     success = True
-    for spec in manifest:
-        if spec['title'] == '':
-            success = False
-            logging.error(f'Spec {spec["path"]} does not have a title')
-        if spec['description'] == '':
-            success = False
-            logging.error(f'Spec {spec["path"]} does not have a description')
+    for path, spec in manifest:
         if not any(spec['authors']):
             success = False
-            logging.error(f'Spec {spec["path"]} does not have any listed authors')
+            logging.error(f'Spec {path} does not have any listed authors')
         for module in spec['modules']:
             module_path = module['path']
             tree, text, parse_err = tla_utils.parse_module(examples_root, parser, module_path)

--- a/.github/scripts/check_manifest_files.py
+++ b/.github/scripts/check_manifest_files.py
@@ -19,7 +19,7 @@ ci_ignore_path = normpath(args.ci_ignore_path)
 examples_root = dirname(ci_ignore_path)
 manifest = tla_utils.load_all_manifests(examples_root)
 
-module_lists = [spec["modules"] for spec in manifest]
+module_lists = [spec["modules"] for path, spec in manifest]
 modules = [module for module_list in module_lists for module in module_list]
 model_lists = [module["models"] for module in modules]
 

--- a/.github/scripts/check_manifest_schema.py
+++ b/.github/scripts/check_manifest_schema.py
@@ -21,8 +21,8 @@ args = parser.parse_args()
 examples_root = dirname(args.schema_path)
 schema = tla_utils.load_json(normpath(args.schema_path))
 failures = []
-for manifest in tla_utils.load_all_manifests(examples_root):
-    manifest_path = join(manifest['path'], "manifest.json")
+for path, manifest in tla_utils.load_all_manifests(examples_root):
+    manifest_path = join(path, 'manifest.json')
     try:
         validate(instance=manifest, schema=schema)
     except ValidationError as error:

--- a/.github/scripts/check_markdown_table.py
+++ b/.github/scripts/check_markdown_table.py
@@ -58,13 +58,13 @@ def from_markdown(record):
         record
     )
 
-def from_json(spec):
+def from_json(path, spec):
     '''
     Transforms JSON from the manifest into a normalized form.
     '''
     return TableRow(
-        spec['title'],
-        spec['path'],
+        '',
+        path,
         set(spec['authors']),
         'beginner' in spec['tags'],
         any([module for module in spec['modules'] if 'proof' in module['features']]),
@@ -87,7 +87,7 @@ with open(normpath(args.readme_path), 'r', encoding='utf-8') as readme_file:
 spec_table = next((child for child in readme.children if isinstance(child, Table)))
 
 table_specs = dict([(record.path, record) for record in [from_markdown(node) for node in spec_table.children]])
-manifest_specs = dict([(record.path, record) for record in [from_json(spec) for spec in manifest]])
+manifest_specs = dict([(record.path, record) for record in [from_json(path, spec) for path, spec in manifest]])
 
 # Checks that set of specs in manifest and table are equivalent
 success = True
@@ -106,18 +106,6 @@ specs = [
     for (path, manifest_spec) in manifest_specs.items()
     if path in table_specs
 ]
-
-# Ensure spec names are identical
-different_names = [
-    (manifest_spec.path, manifest_spec.name, table_spec.name)
-    for (manifest_spec, table_spec) in specs
-    if manifest_spec.name != table_spec.name
-]
-if any(different_names):
-    success = False
-    print('ERROR: spec names in README.md table differ from manifest.json:')
-    for path, json, md in different_names:
-        print(f'Spec {path} has name {json} in manifest and {md} in README')
 
 # Ensure spec authors are identical
 different_authors = [

--- a/.github/scripts/check_proofs.py
+++ b/.github/scripts/check_proofs.py
@@ -27,7 +27,7 @@ logging.basicConfig(level = logging.DEBUG if args.verbose else logging.INFO)
 
 proof_module_paths = [
     module['path']
-    for spec in manifest
+    for path, spec in manifest
     for module in spec['modules']
         if 'proof' in module['features']
         and module['path'] not in skip_modules

--- a/.github/scripts/check_small_models.py
+++ b/.github/scripts/check_small_models.py
@@ -89,7 +89,7 @@ manifest = tla_utils.load_all_manifests(examples_root)
 small_models = sorted(
     [
         (module, model, tla_utils.parse_timespan(model['runtime']))
-        for spec in manifest
+        for path, spec in manifest
         for module in spec['modules']
         for model in module['models']
             if model['size'] == 'small'

--- a/.github/scripts/generate_manifest.py
+++ b/.github/scripts/generate_manifest.py
@@ -10,18 +10,10 @@ manifest.json file or set as blank/unknown as appropriate.
 from check_manifest_features import *
 import os
 from os.path import basename, dirname, join, normpath, relpath, splitext, isfile
-from pathlib import PureWindowsPath
 import glob
 import tla_utils
 import tree_sitter_tlaplus
 from tree_sitter import Language, Parser
-
-def to_posix(path):
-    """
-    Converts paths to normalized Posix format.
-    https://stackoverflow.com/q/75291812/2852699
-    """
-    return PureWindowsPath(normpath(path)).as_posix()
 
 def get_spec_dirs(examples_root, ignored_dirs):
     """
@@ -74,21 +66,18 @@ def generate_new_manifest(examples_root, spec_path, spec_name, parser, queries):
     Generate new manifest.json file for a given specification directory.
     """
     return {
-        'path': to_posix(spec_path),
-        'title': spec_name,
-        'description': '',
         'sources': [],
         'authors': [],
         'tags': [],
         'modules': [
             {
-                'path': to_posix(tla_path),
+                'path': tla_utils.to_posix(tla_path),
                 'communityDependencies': sorted(list(get_community_module_imports(examples_root, parser, tla_path, queries))),
                 'tlaLanguageVersion': 2,
                 'features': sorted(list(get_module_features(examples_root, tla_path, parser, queries))),
                 'models': [
                     {
-                        'path': to_posix(cfg_path),
+                        'path': tla_utils.to_posix(cfg_path),
                         'runtime': 'unknown',
                         'size': 'unknown',
                         'mode': 'exhaustive search',
@@ -108,14 +97,14 @@ def get_old_manifest(spec_path):
     return tla_utils.load_json(old_manifest_path) if isfile(old_manifest_path) else None
 
 def integrate_spec_info(old_manifest, new_spec):
-    fields = ['title', 'description', 'authors', 'sources', 'tags']
+    fields = ['authors', 'sources', 'tags']
     for field in fields:
         new_spec[field] = old_manifest[field]
 
 def find_corresponding_module(old_module, new_spec):
     modules = [
         module for module in new_spec['modules']
-        if to_posix(module['path']) == to_posix(old_module['path'])
+        if tla_utils.to_posix(module['path']) == tla_utils.to_posix(old_module['path'])
     ]
     return modules[0] if any(modules) else None
 
@@ -127,7 +116,7 @@ def integrate_module_info(old_module, new_module):
 def find_corresponding_model(old_model, new_module):
     models = [
         model for model in new_module['models']
-        if to_posix(model['path']) == to_posix(old_model['path'])
+        if tla_utils.to_posix(model['path']) == tla_utils.to_posix(old_model['path'])
     ]
     return models[0] if any(models) else None
 

--- a/.github/scripts/parse_modules.py
+++ b/.github/scripts/parse_modules.py
@@ -68,7 +68,7 @@ manifest = tla_utils.load_all_manifests(examples_root)
 # List of all modules to parse and whether they should use TLAPS imports
 modules = [
     tla_utils.from_cwd(examples_root, module['path'])
-    for spec in manifest
+    for path, spec in manifest
     for module in spec['modules']
         if module['path'] not in skip_modules
         and (only_modules == [] or module['path'] in only_modules)

--- a/.github/scripts/record_model_state_space.py
+++ b/.github/scripts/record_model_state_space.py
@@ -79,7 +79,7 @@ manifest = tla_utils.load_all_manifests(examples_root)
 small_models = sorted(
     [
         (spec, module, model, tla_utils.parse_timespan(model['runtime']))
-        for spec in manifest
+        for path, spec in manifest
         for module in spec['modules']
         for model in module['models']
             if model['size'] == 'small'

--- a/.github/scripts/smoke_test_large_models.py
+++ b/.github/scripts/smoke_test_large_models.py
@@ -82,7 +82,7 @@ manifest = tla_utils.load_all_manifests(examples_root)
 
 large_models = [
     (module, model)
-    for spec in manifest
+    for path, spec in manifest
     for module in spec['modules']
     for model in module['models']
         if model['size'] != 'small'

--- a/.github/scripts/tla_utils.py
+++ b/.github/scripts/tla_utils.py
@@ -1,7 +1,8 @@
 import locale
 from datetime import datetime
 import json
-from os.path import join, normpath, pathsep
+from os.path import join, normpath, pathsep, dirname
+from pathlib import PureWindowsPath
 import subprocess
 import re
 import glob
@@ -13,6 +14,13 @@ def from_cwd(root, path):
     the path from the cwd to that file.
     """
     return normpath(join(root, normpath(path)))
+
+def to_posix(path):
+    """
+    Converts paths to normalized Posix format.
+    https://stackoverflow.com/q/75291812/2852699
+    """
+    return PureWindowsPath(normpath(path)).as_posix()
 
 def ignore(ignored_dirs, path):
     """
@@ -50,9 +58,10 @@ def load_all_manifests(examples_root):
     Loads all manifest.json files in the specifications subdirectories.
     """
     return [
-        load_json(manifest_path)
-        for manifest_path in glob.glob(from_cwd(examples_root, 'specifications/*/manifest.json'))
+        (to_posix(dirname(manifest_path)), load_json(from_cwd(examples_root, manifest_path)))
+        for manifest_path in glob.glob('specifications/*/manifest.json', root_dir = examples_root)
     ]
+
 
 def write_json(data, path):
     """

--- a/.github/scripts/translate_pluscal.py
+++ b/.github/scripts/translate_pluscal.py
@@ -33,7 +33,7 @@ manifest = tla_utils.load_all_manifests(examples_root)
 # List of all modules to translate
 modules = [
     tla_utils.from_cwd(examples_root, module['path'])
-    for spec in manifest
+    for path, spec in manifest
     for module in spec['modules']
         if 'pluscal' in module['features']
         and module['path'] not in skip_modules

--- a/.github/scripts/unicode_conversion.py
+++ b/.github/scripts/unicode_conversion.py
@@ -33,7 +33,7 @@ manifest = tla_utils.load_all_manifests(examples_root)
 # List of all modules to convert
 modules = [
     tla_utils.from_cwd(examples_root, module['path'])
-    for spec in manifest
+    for path, spec in manifest
     for module in spec['modules']
         if module['path'] not in skip_modules
         and (only_modules == [] or module['path'] in only_modules)

--- a/manifest-schema.json
+++ b/manifest-schema.json
@@ -1,11 +1,8 @@
 {
   "type": "object",
-  "required": ["title", "description", "sources", "authors", "path", "tags", "modules"],
+  "required": ["sources", "authors", "tags", "modules"],
   "additionalProperties": false,
   "properties": {
-    "path": {"type": "string"},
-    "title": {"type": "string"},
-    "description": {"type": "string"},
     "sources": {
       "type": "array",
       "items": {"type": "string"}

--- a/specifications/Bakery-Boulangerie/manifest.json
+++ b/specifications/Bakery-Boulangerie/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Bakery-Boulangerie",
-  "title": "The Boulangerie Algorithm",
-  "description": "Spec of a variant of the Bakery Algorithm",
   "sources": [],
   "authors": [
     "Leslie Lamport",

--- a/specifications/CarTalkPuzzle/manifest.json
+++ b/specifications/CarTalkPuzzle/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/CarTalkPuzzle",
-  "title": "The Car Talk Puzzle",
-  "description": "Math puzzle involving a farmer, a stone, and a balance scale",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/Chameneos/manifest.json
+++ b/specifications/Chameneos/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Chameneos",
-  "title": "Chameneos, a Concurrency Game",
-  "description": "A concurrency game requiring concurrent & symmetric cooperation",
   "sources": [
     "https://github.com/mryndzionek/tlaplus_specs#chameneostla"
   ],

--- a/specifications/CheckpointCoordination/manifest.json
+++ b/specifications/CheckpointCoordination/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/CheckpointCoordination",
-  "title": "Checkpoint Coordination",
-  "description": "An algorithm for controlling checkpoint leases in a Paxos ring",
   "sources": [
     "https://github.com/Azure/RingMaster",
     "https://ahelwer.ca/post/2023-04-05-checkpoint-coordination/"

--- a/specifications/CigaretteSmokers/manifest.json
+++ b/specifications/CigaretteSmokers/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/CigaretteSmokers",
-  "title": "The Cigarette Smokers Problem",
-  "description": "A concurrency problem described in 1971 by Suhas Patil",
   "sources": [
     "https://github.com/mryndzionek/tlaplus_specs#cigarettesmokerstla"
   ],

--- a/specifications/CoffeeCan/manifest.json
+++ b/specifications/CoffeeCan/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/CoffeeCan",
-  "title": "The Coffee Can Bean Problem",
-  "description": "Math problem published by Dijkstra attributed to Carel Scholten",
   "sources": [
     "https://stackoverflow.com/a/66304920/2852699"
   ],

--- a/specifications/DieHard/manifest.json
+++ b/specifications/DieHard/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/DieHard",
-  "title": "The Die Hard Problem",
-  "description": "Obtain 4 gallons of water using only 3 and 5 gallon jugs",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/DiningPhilosophers/manifest.json
+++ b/specifications/DiningPhilosophers/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/DiningPhilosophers",
-  "title": "The Dining Philosophers Problem",
-  "description": "The Chandy-Misra solution to the Dining Philosophers concurrency problem",
   "sources": [],
   "authors": [
     "Jeff Hemphill"

--- a/specifications/Disruptor/manifest.json
+++ b/specifications/Disruptor/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Disruptor",
-  "title": "Disruptor",
-  "description": "Models single and multi producer scenarios of the Disruptor library and checks for data races.",
   "sources": [
     "https://github.com/nicholassm/disruptor-rs"
   ],

--- a/specifications/EinsteinRiddle/manifest.json
+++ b/specifications/EinsteinRiddle/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/EinsteinRiddle",
-  "title": "Einstein's Riddle",
-  "description": "Five houses, five people, various facts, who lives in what house?",
   "sources": [],
   "authors": [
     "Isaac DeFrain",

--- a/specifications/FiniteMonotonic/manifest.json
+++ b/specifications/FiniteMonotonic/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/FiniteMonotonic",
-  "title": "Finitizing Monotonic Systems",
-  "description": "Illustration of technique for making ordinarily-infinite monotonic systems finite for the purposes of model-checking.",
   "sources": [
     "https://ahelwer.ca/post/2023-11-01-tla-finite-monotonic/"
   ],

--- a/specifications/GameOfLife/manifest.json
+++ b/specifications/GameOfLife/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/GameOfLife",
-  "title": "Conway's Game of Life",
-  "description": "The famous cellular automata simulation",
   "sources": [
     "https://github.com/mryndzionek/tlaplus_specs#gameoflifetla"
   ],

--- a/specifications/Huang/manifest.json
+++ b/specifications/Huang/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Huang",
-  "title": "Huang's Algorithm",
-  "description": "An algorithm for detecting termination in a distributed system",
   "sources": [],
   "authors": [
     "Markus Kuppe"

--- a/specifications/KeyValueStore/manifest.json
+++ b/specifications/KeyValueStore/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/KeyValueStore",
-  "title": "Snapshot Key-Value Store",
-  "description": "A simple KVS implementing snapshot isolation",
   "sources": [],
   "authors": [
     "Andrew Helwer",

--- a/specifications/KnuthYao/manifest.json
+++ b/specifications/KnuthYao/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/KnuthYao",
-  "title": "The Knuth-Yao Method",
-  "description": "A method for simulating a fair 6-sided die using only coin flips",
   "sources": [
     "https://old.reddit.com/r/tlaplus/comments/j06ohw/how_do_you_reason_about_a_probabilistic/g6owlxy/"
   ],

--- a/specifications/LearnProofs/manifest.json
+++ b/specifications/LearnProofs/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/LearnProofs",
-  "title": "Learn TLA⁺ Proofs",
-  "description": "Some specs of very simple algorithms & formal proofs of their correctness",
   "sources": [],
   "authors": [
     "Andrew Helwer"

--- a/specifications/LeastCircularSubstring/manifest.json
+++ b/specifications/LeastCircularSubstring/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/LeastCircularSubstring",
-  "title": "Minimal Circular Substring",
-  "description": "Booth's 1980 algorithm to find the lexicographically-least circular substring",
   "sources": [
     "https://ahelwer.ca/post/2023-03-30-pseudocode/"
   ],

--- a/specifications/LevelChecking/manifest.json
+++ b/specifications/LevelChecking/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/LevelChecking",
-  "title": "TLA⁺ Level Checking",
-  "description": "Level-checking of TLA⁺ formulas as described in Specifying Systems",
   "sources": [
     "https://github.com/tlaplus/tlaplus/blob/6bc82f7746ccdfbdf49cdef24448666d11e5e218/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelNode.java#L354-L2778"
   ],

--- a/specifications/LoopInvariance/manifest.json
+++ b/specifications/LoopInvariance/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/LoopInvariance",
-  "title": "Loop Invariance",
-  "description": "Examples of finding and proving loop invariants in PlusCal",
   "sources": [
     "http://lamport.azurewebsites.net/tla/proving-safety.pdf"
   ],

--- a/specifications/Majority/manifest.json
+++ b/specifications/Majority/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Majority",
-  "title": "Boyer-Moore Majority Vote",
-  "description": "An efficient algorithm for detecting a majority value in a sequence",
   "sources": [],
   "authors": [
     "Stephan Merz"

--- a/specifications/MisraReachability/manifest.json
+++ b/specifications/MisraReachability/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/MisraReachability",
-  "title": "Misra Reachability Algorithm",
-  "description": "A sequential algorithm for computing the set of reachable nodes in a directed graph",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/MissionariesAndCannibals/manifest.json
+++ b/specifications/MissionariesAndCannibals/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/MissionariesAndCannibals",
-  "title": "Missionaries and Cannibals",
-  "description": "Spec of a river-crossing puzzle",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/Moving_Cat_Puzzle/manifest.json
+++ b/specifications/Moving_Cat_Puzzle/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Moving_Cat_Puzzle",
-  "title": "The Moving Cat Puzzle",
-  "description": "Demonstrating the solution for the moving cat puzzle is correct.",
   "sources": [],
   "authors": [
     "Florian Schanda"

--- a/specifications/MultiCarElevator/manifest.json
+++ b/specifications/MultiCarElevator/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/MultiCarElevator",
-  "title": "Multi-Car Elevator System",
-  "description": "A simple multi-car elevator system servicing a multi-floor building",
   "sources": [
     "https://groups.google.com/g/tlaplus/c/5Xd8kv288jE/m/IrliJIatBwAJ"
   ],

--- a/specifications/MultiPaxos-SMR/manifest.json
+++ b/specifications/MultiPaxos-SMR/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/MultiPaxos-SMR",
-  "title": "MultiPaxos in SMR-Style",
-  "description": "MultiPaxos in practical state machine replication system style",
   "sources": [
     "https://www.josehu.com/technical/2024/02/19/practical-MultiPaxos-TLA-spec.html"
   ],

--- a/specifications/N-Queens/manifest.json
+++ b/specifications/N-Queens/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/N-Queens",
-  "title": "The N-Queens Puzzle",
-  "description": "Place N queens on an NxN chess board such that no two queens threaten each other",
   "sources": [],
   "authors": [
     "Stephan Merz"

--- a/specifications/NanoBlockchain/manifest.json
+++ b/specifications/NanoBlockchain/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/NanoBlockchain",
-  "title": "Nano Blockchain Protocol",
-  "description": "A specification of the protocol originally used by the Nano blockchain",
   "sources": [],
   "authors": [
     "Andrew Helwer"

--- a/specifications/Paxos/manifest.json
+++ b/specifications/Paxos/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Paxos",
-  "title": "The Paxos Protocol",
-  "description": "A protocol for error-tolerant consensus",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/PaxosHowToWinATuringAward/manifest.json
+++ b/specifications/PaxosHowToWinATuringAward/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/PaxosHowToWinATuringAward",
-  "title": "Paxos (How to Win a Turing Award)",
-  "description": "Exercises from the lecture The Paxos Algorithm - or How to Win a Turing Award",
   "sources": [
     "https://www.youtube.com/watch?v=tw3gsBms-f8"
   ],

--- a/specifications/Prisoners/manifest.json
+++ b/specifications/Prisoners/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Prisoners",
-  "title": "The Prisoners & Switches Puzzle",
-  "description": "Given a room containing two switches prisoners enter one by one, they must develop a strategy to free themselves",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/Prisoners_Single_Switch/manifest.json
+++ b/specifications/Prisoners_Single_Switch/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Prisoners_Single_Switch",
-  "title": "The Prisoners & Switch Puzzle",
-  "description": "Given a room containing a single light switch prisoners enter one by one, they must develop a strategy to free themselves.",
   "sources": [],
   "authors": [
     "Florian Schanda"

--- a/specifications/ReadersWriters/manifest.json
+++ b/specifications/ReadersWriters/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/ReadersWriters",
-  "title": "The Readers-Writers Problem",
-  "description": "Controlling concurrent access to a resource",
   "sources": [],
   "authors": [
     "Isaac DeFrain"

--- a/specifications/SDP_Verification/manifest.json
+++ b/specifications/SDP_Verification/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/SDP_Verification",
-  "title": "Software-Defined Perimeter",
-  "description": "Specifying and verifying SDP-protocol-based zero trust architecture",
   "sources": [
     "https://github.com/10227694/SDP_Verification"
   ],

--- a/specifications/SimplifiedFastPaxos/manifest.json
+++ b/specifications/SimplifiedFastPaxos/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/SimplifiedFastPaxos",
-  "title": "Simplified Fast Paxos",
-  "description": "Spec of simplified Fast Paxos from Lamport's 2006 paper Fast Paxos",
   "sources": [],
   "authors": [
     "Lim Ngian Xin Terry",

--- a/specifications/SingleLaneBridge/manifest.json
+++ b/specifications/SingleLaneBridge/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/SingleLaneBridge",
-  "title": "Single-Lane Bridge Problem",
-  "description": "Controlling cars moving over a single-lange bridge in opposite directions",
   "sources": [],
   "authors": [
     "Younes Akhouayri"

--- a/specifications/SlidingPuzzles/manifest.json
+++ b/specifications/SlidingPuzzles/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/SlidingPuzzles",
-  "title": "Sliding Block Puzzle",
-  "description": "A spec of the Klotski sliding block puzzle",
   "sources": [],
   "authors": [
     "Mariusz Ryndzionek"

--- a/specifications/SlushProtocol/manifest.json
+++ b/specifications/SlushProtocol/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/SlushProtocol",
-  "title": "The Slush Protocol",
-  "description": "An attempt to use TLA⁺ to analyze a probabilistic protocol in the Avalanche family",
   "sources": [
     "https://github.com/ahelwer/avalanche-analysis",
     "https://ahelwer.ca/post/2020-09-11-probabilistic-distsys/"

--- a/specifications/SpanningTree/manifest.json
+++ b/specifications/SpanningTree/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/SpanningTree",
-  "title": "Span Tree Exercise",
-  "description": "Simplified algorithm from the Lamport paper *An Assertional Correctness Proof of a Distributed Program*",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/SpecifyingSystems/manifest.json
+++ b/specifications/SpecifyingSystems/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/SpecifyingSystems",
-  "title": "Specs from Specifying Systems",
-  "description": "All specs seen in the textbook Specifying Systems by Leslie Lamport",
   "sources": [
     "http://lamport.azurewebsites.net/tla/book.html"
   ],

--- a/specifications/Stones/manifest.json
+++ b/specifications/Stones/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/Stones",
-  "title": "Stone Scale Puzzle",
-  "description": "Alternative implementation of the Car Talk Puzzle",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/TLC/manifest.json
+++ b/specifications/TLC/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/TLC",
-  "title": "The TLC Safety Checking Algorithm",
-  "description": "Spec of the safety checking algorithm used by the TLC model-checker",
   "sources": [],
   "authors": [
     "Markus Kuppe"

--- a/specifications/TeachingConcurrency/manifest.json
+++ b/specifications/TeachingConcurrency/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/TeachingConcurrency",
-  "title": "Teaching Concurrency",
-  "description": "Simple problem useful for teaching and learning about concurrency",
   "sources": [
     "http://lamport.azurewebsites.net/pubs/teaching-concurrency.pdf"
   ],

--- a/specifications/TransitiveClosure/manifest.json
+++ b/specifications/TransitiveClosure/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/TransitiveClosure",
-  "title": "Transitive Closure",
-  "description": "Spec defining the transitive closure of a relation",
   "sources": [],
   "authors": [
     "Stephan Merz"

--- a/specifications/TwoPhase/manifest.json
+++ b/specifications/TwoPhase/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/TwoPhase",
-  "title": "Two-Phase Handshaking",
-  "description": "Specification of a very simple hardware protocol called two-phase handshaking",
   "sources": [],
   "authors": [
     "Leslie Lamport",

--- a/specifications/YoYo/manifest.json
+++ b/specifications/YoYo/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/YoYo",
-  "title": "Yo-Yo Leader Election",
-  "description": "Algorithm due to Nicola Santoro for leader election in a connected undirected network",
   "sources": [
     "https://research.nicola-santoro.com/DADA.html"
   ],

--- a/specifications/aba-asyn-byz/manifest.json
+++ b/specifications/aba-asyn-byz/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/aba-asyn-byz",
-  "title": "Asynchronous Byzantine Consensus",
-  "description": "Spec of the protocol from paper *Asynchronous Consensus and Broadcast Protocols* (1985)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/acp/manifest.json
+++ b/specifications/acp/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/acp",
-  "title": "Atomic Commitment Protocol",
-  "description": "TLA⁺ specs from CS-986: Advanced Topics in Program Verification",
   "sources": [
     "https://members.loria.fr/SMerz/talks/argentina2005/Charpentier/charpov/Teaching/CS-986/TLC/",
     "https://dl.acm.org/doi/10.5555/302430.302436"

--- a/specifications/allocator/manifest.json
+++ b/specifications/allocator/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/allocator",
-  "title": "Resource Allocator",
-  "description": "Specification of a resource allocator",
   "sources": [],
   "authors": [
     "Stephan Merz"

--- a/specifications/barriers/manifest.json
+++ b/specifications/barriers/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/barriers",
-  "title": "Barrier Synchronization",
-  "description": "Barriers ensure a group of threads all reach the barrier before advancing",
   "sources": [
     "http://hdl.handle.net/2268.2/23374"
   ],

--- a/specifications/bcastByz/manifest.json
+++ b/specifications/bcastByz/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/bcastByz",
-  "title": "Asynchronous Reliable Broadcast",
-  "description": "Algorithm from paper *Simulating authenticated broadcasts to derive simple fault-tolerant algorithms* (1987)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/bcastFolklore/manifest.json
+++ b/specifications/bcastFolklore/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/bcastFolklore",
-  "title": "Folklore Reliable Broadcast",
-  "description": "Algorithm from paper *Unreliable failure detectors for reliable distributed systems* (1996)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/bosco/manifest.json
+++ b/specifications/bosco/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/bosco",
-  "title": "The Bosco Byzantine Consensus Algorithm",
-  "description": "Algorithm from paper *Bosco: One-step byzantine asynchronous consensus* (2008)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/braf/manifest.json
+++ b/specifications/braf/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/braf",
-  "title": "Buffered Random Access File",
-  "description": "Specification of a Java file caching layer",
   "sources": [
     "https://github.com/tlaplus/tlaplus/tree/4613109641676389d97b8df209d6cf4d90d31c1c/tlatools/org.lamport.tlatools/src/tlc2/util/BufferedRandomAccessFile.tla"
   ],

--- a/specifications/btree/manifest.json
+++ b/specifications/btree/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/btree",
-  "title": "B-trees",
-  "description": "Operations on B-trees. Includes a refinement mapping to a key-value store spec.",
   "sources": [
     "https://github.com/lorin/btree-tla",
     "https://surfingcomplexity.blog/2024/07/04/modeling-b-trees-in-tla/"

--- a/specifications/byihive/manifest.json
+++ b/specifications/byihive/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/byihive",
-  "title": "RFC 3506: Voucher Transaction System",
-  "description": "Formal specification of a peer-to-peer ledger protocol",
   "sources": [
     "https://github.com/byisystems/byihive"
   ],

--- a/specifications/byzpaxos/manifest.json
+++ b/specifications/byzpaxos/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/byzpaxos",
-  "title": "Byzantizing Paxos by Refinement",
-  "description": "Mechanically-checked safety proof of a Byzantine Paxos algorithm",
   "sources": [
     "http://lamport.azurewebsites.net/pubs/pubs.html#web-byzpaxos",
     "http://lamport.azurewebsites.net/pubs/web-byzpaxos.pdf",

--- a/specifications/c1cs/manifest.json
+++ b/specifications/c1cs/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/c1cs",
-  "title": "Consensus in One Communication Step",
-  "description": "Algorithm from paper *Consensus in one communication step* (2001)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/cbc_max/manifest.json
+++ b/specifications/cbc_max/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/cbc_max",
-  "title": "Condition-Based Consensus",
-  "description": "Algorithm from paper *Evaluating the condition-based approach to solve consensus* (2003)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/cf1s-folklore/manifest.json
+++ b/specifications/cf1s-folklore/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/cf1s-folklore",
-  "title": "One-Step Consensus with Zero-Degradation",
-  "description": "Algorithm from paper *One-step Consensus with Zero-Degradation* (2006)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/chang_roberts/manifest.json
+++ b/specifications/chang_roberts/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/chang_roberts",
-  "title": "Chang-Roberts Algorithm for Leader Election in a Ring",
-  "description": "Algorithm from paper *An improved algorithm for decentralized extrema-finding in circular configurations of processes* (1979)",
   "sources": [],
   "authors": [
     "Stephan Merz"

--- a/specifications/detector_chan96/manifest.json
+++ b/specifications/detector_chan96/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/detector_chan96",
-  "title": "Failure Detector",
-  "description": "Algorithm from paper *Unreliable failure detectors for reliable distributed systems* (1996)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/dijkstra-mutex/manifest.json
+++ b/specifications/dijkstra-mutex/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/dijkstra-mutex",
-  "title": "Dijkstra's Mutual Exclusion Algorithm",
-  "description": "Algorithm from paper *Solution of a Problem in Concurrent Programming Control* (1965)",
   "sources": [],
   "authors": [
     "Leslie Lamport"

--- a/specifications/diskpaxos/manifest.json
+++ b/specifications/diskpaxos/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/diskpaxos",
-  "title": "SWMR Shared Memory Disk Paxos",
-  "description": "A formalization of the SWMR-Shared-Memory Disk Paxos",
   "sources": [
     "https://github.com/nano-o/MultiPaxos/blob/master/DiskPaxos.tla"
   ],

--- a/specifications/echo/manifest.json
+++ b/specifications/echo/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/echo",
-  "title": "The Echo Algorithm",
-  "description": "Algorithm for constructing a spanning tree in an undirected graph",
   "sources": [],
   "authors": [
     "Stephan Merz"

--- a/specifications/ewd426/manifest.json
+++ b/specifications/ewd426/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/ewd426",
-  "title": "EWD 426: Token Stabilization",
-  "description": "Dijkstra's classical stabilizing token ring algorithm, EWD426",
   "sources": [],
   "authors": [
     "Markus Kuppe",

--- a/specifications/ewd687a/manifest.json
+++ b/specifications/ewd687a/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/ewd687a",
-  "title": "EWD687a: Detecting Termination in Distributed Computations",
-  "description": "Dijkstra's Termination Detection Algorithm",
   "sources": [],
   "authors": [
     "Leslie Lamport",

--- a/specifications/ewd840/manifest.json
+++ b/specifications/ewd840/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/ewd840",
-  "title": "EWD840: Termination Detection in a Ring",
-  "description": "EWD840: Termination Detection in a Ring",
   "sources": [
     "Dijkstra's termination detection algorithm for ring topologies"
   ],

--- a/specifications/ewd998/manifest.json
+++ b/specifications/ewd998/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/ewd998",
-  "title": "EWD998: Termination Detection in a Ring with Asynchronous Message Delivery",
-  "description": "Variant of EWD 840 given by Shmuel Safra",
   "sources": [],
   "authors": [
     "Markus Kuppe",

--- a/specifications/glowingRaccoon/manifest.json
+++ b/specifications/glowingRaccoon/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/glowingRaccoon",
-  "title": "PCR Testing for Snippets of DNA",
-  "description": "Specification of a PCR test process",
   "sources": [],
   "authors": [
     "Martin Harrison"

--- a/specifications/lamport_mutex/manifest.json
+++ b/specifications/lamport_mutex/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/lamport_mutex",
-  "title": "Distributed Mutual Exclusion",
-  "description": "Specification of Lamport's distributed mutual exclusion algorithm",
   "sources": [],
   "authors": [
     "Stephan Merz"

--- a/specifications/locks_auxiliary_vars/manifest.json
+++ b/specifications/locks_auxiliary_vars/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/locks_auxiliary_vars",
-  "title": "Peterson Lock Refinement With Auxiliary Variables",
-  "description": "Two-way refinement between Peterson's Algorithm and an abstract lock spec, using auxiliary variables as presented in *Prophecy made simple* by Lamport and Merz",
   "sources": [
     "http://hdl.handle.net/2268.2/23374"
   ],

--- a/specifications/nbacc_ray97/manifest.json
+++ b/specifications/nbacc_ray97/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/nbacc_ray97",
-  "title": "Asynchronous Non-Blocking Atomic Commit",
-  "description": "Algorithm from paper *A case study of agreement problems in distributed systems: non-blocking atomic commitment* (1997)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/nbacg_guer01/manifest.json
+++ b/specifications/nbacg_guer01/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/nbacg_guer01",
-  "title": "Asynchronous Non-Blocking Atomic Commitment with Failure Detectors",
-  "description": "Algorithm from paper *On the hardness of failure-sensitive agreement problems* (2001)",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/spanning/manifest.json
+++ b/specifications/spanning/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/spanning",
-  "title": "Spanning Tree Broadcast Algorithm",
-  "description": "A spanning tree broadcast algorithm",
   "sources": [],
   "authors": [
     "Igor Konnov",

--- a/specifications/sums_even/manifest.json
+++ b/specifications/sums_even/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/sums_even",
-  "title": "Proof x+x is Even",
-  "description": "Two proofs that x+x is even for every natural number x",
   "sources": [],
   "authors": [
     "Martin Riener"

--- a/specifications/tcp/manifest.json
+++ b/specifications/tcp/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/tcp",
-  "title": "TCP as defined in RFC 9293",
-  "description": "Transmission Control Protocol (TCP)",
   "sources": [
     "https://datatracker.ietf.org/doc/html/rfc9293"
   ],

--- a/specifications/tower_of_hanoi/manifest.json
+++ b/specifications/tower_of_hanoi/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/tower_of_hanoi",
-  "title": "The Tower of Hanoi Puzzle",
-  "description": "Famous puzzle involving stacking disks on towers",
   "sources": [],
   "authors": [
     "Alexander Niederbühl",

--- a/specifications/transaction_commit/manifest.json
+++ b/specifications/transaction_commit/manifest.json
@@ -1,7 +1,4 @@
 {
-  "path": "specifications/transaction_commit",
-  "title": "Transaction Commit Models",
-  "description": "Ordinary transaction commit, two-phase commit, and Paxos commit",
   "sources": [
     "http://research.microsoft.com/en-us/um/people/lamport/pubs/pubs.html#paxos-commit",
     "https://www.microsoft.com/en-us/research/uploads/prod/2004/01/consensus-on-transaction-commit.pdf",


### PR DESCRIPTION
In furtherance of https://github.com/tlaplus/Examples/issues/171

The path property is now inherent in the location of the manifest.json file, the README.md table can be the source of truth for the spec title, and the spec description can live in the directory-specific README.md file.