### PR TITLE
CI: use bash instead of python for proof checking

### DIFF
--- a/.github/scripts/linux-setup.sh
+++ b/.github/scripts/linux-setup.sh
@@ -48,6 +48,7 @@ main() {
   mkdir -p "$DEPS_DIR/community"
   wget -nv https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar \
         -O "$DEPS_DIR/community/modules.jar"
+  unzip "$DEPS_DIR/community/modules.jar" -d "$DEPS_DIR/community/"
   # Get TLAPS modules
   wget -nv https://github.com/tlaplus/tlapm/archive/main.tar.gz -O /tmp/tlapm.tar.gz
   tar -xzf /tmp/tlapm.tar.gz --directory "$DEPS_DIR"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,9 +135,40 @@ jobs:
       - name: Check proofs
         if: matrix.os != 'windows-latest' && !matrix.unicode
         run: |
-          python $SCRIPT_DIR/check_proofs.py       \
-            --tlapm_path $DEPS_DIR/tlapm           \
-            --examples_root .
+          # Exempting specs for various reasons:
+          # - Use of RECURSIVE, which TLAPM cannot currently handle (many)
+          # - Pre-module text bug (MCDistributedReplicatedLog.tla)
+          # - Unresolved ToString operator (ewd840)
+          # - Use of nonstandard TLCExt module (SimKnuthYao.tla)
+          # - Use of nonstandard Randomization module (SpanTreeTest.tla)
+          # - Nonstandard multi-module (BufferedRandomAccessFile.tla)
+          # - Nested module identifier bug (diskpaxos, Composing, RealTime)
+          # - TLAPM level-checking failure (YoYoPruning.tla)
+          # - Use of Apalache module (Einstein.tla)
+          # - Very long-running proof (BPConProof.tla)
+          find specifications -type f -iname "*.tla"            \
+            \(                                                  \
+                   -not -name "Chameneos.tla"                   \
+              -and -not -name "ReachabilityTest.tla"            \
+              -and -not -name "MCReachabilityTest.tla"          \
+              -and -not -name "MCDistributedReplicatedLog.tla"  \
+              -and -not -name "SimKnuthYao.tla"                 \
+              -and -not -name "SpanTreeTest.tla"                \
+              -and -not -name "TransitiveClosure.tla"           \
+              -and -not -name "BufferedRandomAccessFile.tla"    \
+              -and -not -name "YoYoPruning.tla"                 \
+              -and -not -name "MCYoYoPruning.tla"               \
+              -and -not -name "Einstein.tla"                    \
+              -and -not -name "BPConProof.tla"                  \
+              -and -not -wholename "*/Composing/*"              \
+              -and -not -wholename "*/RealTime/*"               \
+              -and -not -wholename "*/LeastCircularSubstring/*" \
+              -and -not -wholename "*/diskpaxos/*"              \
+              -and -not -wholename "*/ewd998/*"                 \
+              -and -not -wholename "*/ewd840/*"                 \
+            \)                                                  \
+            -print0 | xargs -0 -n1 -r -t               \
+            time $DEPS_DIR/tlapm/bin/tlapm --cleanfp --stretch 5 -I $DEPS_DIR/community
       - name: Smoke-test manifest generation script
         run: |
           python $SCRIPT_DIR/generate_manifest.py \

--- a/specifications/CoffeeCan/manifest.json
+++ b/specifications/CoffeeCan/manifest.json
@@ -15,7 +15,7 @@
       "models": [
         {
           "path": "specifications/CoffeeCan/CoffeeCan1000Beans.cfg",
-          "runtime": "00:00:15",
+          "runtime": "00:00:45",
           "mode": "exhaustive search",
           "result": "success",
           "distinctStates": 501500,


### PR DESCRIPTION
macOS runners also seem to be getting slower, so skip checking one of the CoffeeCan models.