### PR TITLE
Fall back to Apalache v0.52.2 if latest download fails

### DIFF
--- a/.github/scripts/linux-setup.sh
+++ b/.github/scripts/linux-setup.sh
@@ -42,7 +42,9 @@ main() {
   mkdir -p "$DEPS_DIR/tools"
   wget -nv http://nightly.tlapl.us/dist/tla2tools.jar -P "$DEPS_DIR/tools"
   # Get Apalache
-  wget -nv https://github.com/informalsystems/apalache/releases/latest/download/apalache.tgz -O /tmp/apalache.tgz
+  APALACHE_LATEST="https://github.com/apalache-mc/apalache/releases/latest/download/apalache.tgz"
+  APALACHE_FALLBACK="https://github.com/apalache-mc/apalache/releases/download/v0.52.2/apalache.tgz"
+  wget -nv "$APALACHE_LATEST" -O /tmp/apalache.tgz || wget -nv "$APALACHE_FALLBACK" -O /tmp/apalache.tgz
   tar -xzf /tmp/apalache.tgz --directory "$DEPS_DIR"
   # Get TLA⁺ community modules
   mkdir -p "$DEPS_DIR/community"

--- a/.github/scripts/windows-setup.sh
+++ b/.github/scripts/windows-setup.sh
@@ -38,7 +38,9 @@ main() {
   mkdir -p "$DEPS_DIR/tools"
   curl http://nightly.tlapl.us/dist/tla2tools.jar --output "$DEPS_DIR/tools/tla2tools.jar"
   # Get Apalache
-  curl -L https://github.com/informalsystems/apalache/releases/latest/download/apalache.zip --output apalache.zip
+  APALACHE_LATEST="https://github.com/apalache-mc/apalache/releases/latest/download/apalache.zip"
+  APALACHE_FALLBACK="https://github.com/apalache-mc/apalache/releases/download/v0.52.2/apalache.zip"
+  curl -L --fail "$APALACHE_LATEST" --output apalache.zip || curl -L --fail "$APALACHE_FALLBACK" --output apalache.zip
   7z x apalache.zip
   mv apalache "$DEPS_DIR/"
   rm apalache.zip


### PR DESCRIPTION
Related to Github issue #1353
https://github.com/tlaplus/tlaplus/issues/1353
Related to Github issue #3282
https://github.com/apalache-mc/apalache/issues/3282

[Build]