### PR TITLE
Add QuantumArithmetic specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Here is a list of specs included in this repository which are validated by the C
 | [Buffered Random Access File](specifications/braf)                                                  | Calvin Loncaric                                     |          |             |         |     ✔     |          |
 | [Disruptor](specifications/Disruptor)                                                               | Nicholas Schultz-Møller                             |          |             |         |     ✔     |          |
 | [DAG-based Consensus](specifications/dag-consensus)                                                 | Giuliano Losa                                       |          |             |    ✔    |     ✔     |          |
+| [Quantum Arithmetic Axiom System](specifications/QuantumArithmetic)                                 | Will Dale                                           |          |             |         |     ✔     |          |
 
 
 ## Other Examples

--- a/specifications/QuantumArithmetic/LICENSE
+++ b/specifications/QuantumArithmetic/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Dale
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/specifications/QuantumArithmetic/NOTICE.md
+++ b/specifications/QuantumArithmetic/NOTICE.md
@@ -1,0 +1,51 @@
+Attribution Notice
+------------------
+
+This package is extracted from the `signal_experiments` monorepo (Will
+Dale, 2026) for submission to `github.com/tlaplus/examples`. The TLA+
+logic (generator algebra, axiom invariants, non-vacuity specs) is
+unchanged from its repo-internal canonical form; only the module
+identifiers and file names were renamed (to `QuantumArithmetic` /
+`QuantumArithmeticAxioms` / `QuantumArithmeticAxioms_negative_*`) to
+match the naming conventions of the upstream `tlaplus/examples` corpus.
+The MIT `LICENSE` in this directory governs use of the package; this
+`NOTICE.md` records the requested citation form.
+
+You may copy and reuse this construction and the accompanying TLC
+configurations for research or teaching.
+
+If you publish results that depend on:
+
+  - the QARM generator semantics (sigma, mu, lambda_k with paired
+    failure actions and absorbing-stutter on failure),
+  - the duo-modular qtag packing `qtag = 24*phi9(a) + phi24(a)`,
+  - the observer-layer firewall encoding (`obs_float`,
+    `obs_cross_count`, `Project` action, `Inv_T2_FirewallRespected`,
+    `Inv_NT_NoObserverFeedback`),
+  - the specific invariant set (A1/A2/S1/S2/T1/T2/NT) as named here,
+  - the paired non-vacuity discipline (one negative spec per
+    runtime-checkable invariant, producing a minimal counterexample),
+
+please cite:
+
+  Dale, W. (2026). *Quantum Arithmetic Axiom System as TLA+ Temporal
+  Invariants.* `github.com/tlaplus/examples/specifications/QuantumArithmetic`
+  (extracted from the `signal_experiments` research monorepo).
+
+and preserve:
+
+  - the invariant names (`Inv_A1_NoZero`, etc.),
+  - the observer-layer variable names (`obs_float`, `obs_cross_count`),
+  - the `Project` action signature (writes `obs_cross_count' = 2`,
+    reads `a`).
+
+## References (primary)
+
+- Lamport, L. (1994). *The Temporal Logic of Actions.* ACM TOPLAS 16(3),
+  872-923. DOI: 10.1145/177492.177726.
+- Lamport, L. (2002). *Specifying Systems: The TLA+ Language and Tools
+  for Hardware and Software Engineers.* Addison-Wesley. ISBN
+  978-0-321-14306-8.
+
+These primary references are not subject to this attribution notice and
+should be cited independently per their own terms.

--- a/specifications/QuantumArithmetic/QuantumArithmetic.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmetic.cfg
@@ -1,0 +1,13 @@
+CONSTANTS
+  CAP = 20
+  KSet = {2, 3}
+
+INIT Init
+NEXT Next
+
+INVARIANTS
+  Inv_TupleClosed
+  Inv_InBounds
+  Inv_QDef
+  Inv_FailDomain
+  Inv_MoveDomain

--- a/specifications/QuantumArithmetic/QuantumArithmetic.tla
+++ b/specifications/QuantumArithmetic/QuantumArithmetic.tla
@@ -1,0 +1,249 @@
+------------------------------ MODULE QuantumArithmetic ------------------------------
+EXTENDS Naturals, Integers, TLC
+
+(*
+  QuantumArithmetic.tla — Quantum Arithmetic generator algebra.
+  ------------------------------------------------------------------------
+
+  This module specifies the state machine of the Quantum Arithmetic
+  Reachability Module (QARM): a discrete system over pairs (b, e) with
+  derived coordinates d = b + e, a = b + 2e (equivalently a = d + e), a
+  duo-modular invariant qtag = 24*phi9(a) + phi24(a) \in [0, 239], and
+  three generator actions:
+
+    sigma  : e -> e + 1                            (e-growth)
+    mu     : swap b <-> e                          (coordinate swap)
+    lambda : (b, e) -> (k*b, k*e) for k in KSet    (scaling)
+
+  Each generator is paired with explicit failure actions — OUT_OF_BOUNDS
+  when the successor tuple would exceed CAP, FIXED_Q_VIOLATION when the
+  successor would break duo-modular invariance. Failure states are
+  absorbing: once fail /= "OK", the tuple is frozen.
+
+  This file restricts Init to b, e \in 1..CAP (rather than 0..CAP), so
+  QA Axiom A1 (No-Zero) holds structurally over the reachable state
+  graph. See README.md and the sibling module QuantumArithmeticAxioms.tla
+  for the full axiom set.
+
+  Primary references:
+    - Lamport, L. (1994). The Temporal Logic of Actions. ACM TOPLAS 16(3),
+      872-923. DOI: 10.1145/177492.177726.
+    - Lamport, L. (2002). Specifying Systems: The TLA+ Language and Tools
+      for Hardware and Software Engineers. Addison-Wesley.
+      ISBN 978-0-321-14306-8.
+
+  TLC requirements:
+    - CAP finite (e.g. 20..50)
+    - KSet finite (e.g. {2, 3})
+
+  See QuantumArithmetic.cfg for the standard bounded model.
+*)
+
+CONSTANTS
+  CAP,          \* bound on b,e,d,a
+  KSet          \* finite set of scaling factors for lambda (e.g. {2,3})
+
+VARIABLES
+  b, e, d, a,
+  qtag,
+  fail,         \* {"OK","OUT_OF_BOUNDS","FIXED_Q_VIOLATION","ILLEGAL"}
+  lastMove      \* {"NONE","σ","μ","λ"}
+
+(*** Helpers ***)
+
+InCap(x) == x \in 0..CAP
+
+DR(n) ==
+  IF n = 0 THEN 0 ELSE 1 + ((n - 1) % 9)
+
+Phi24(n) == n % 24
+Phi9(n)  == DR(n)
+
+QDef(bv, ev, dv, av) == 24 * Phi9(av) + Phi24(av)
+
+TupleClosed(bv, ev, dv, av) ==
+  /\ bv \in Nat /\ ev \in Nat /\ dv \in Nat /\ av \in Nat
+  /\ dv = bv + ev
+  /\ av = dv + ev
+
+InBounds(bv, ev, dv, av) ==
+  /\ InCap(bv) /\ InCap(ev) /\ InCap(dv) /\ InCap(av)
+
+StateOK ==
+  /\ TupleClosed(b, e, d, a)
+  /\ InBounds(b, e, d, a)
+  /\ qtag = QDef(b, e, d, a)
+  /\ fail \in {"OK","OUT_OF_BOUNDS","FIXED_Q_VIOLATION","ILLEGAL"}
+  /\ lastMove \in {"NONE","σ","μ","λ"}
+
+(*** Init — A1-corrected: b, e \in 1..CAP (not 0..CAP) ***)
+
+Init ==
+  /\ b \in 1..CAP             \* A1: No-Zero.
+  /\ e \in 1..CAP             \* A1: No-Zero.
+  /\ d = b + e
+  /\ a = d + e
+  /\ TupleClosed(b, e, d, a)
+  /\ InBounds(b, e, d, a)
+  /\ qtag = QDef(b, e, d, a)
+  /\ fail = "OK"
+  /\ lastMove = "NONE"
+
+(*** Move actions — generator algebra ***)
+
+(*** σ : growth on e by +1; close tuple canonically ***)
+
+SigmaSucc ==
+  LET e2 == e + 1 IN
+  LET b2 == b IN
+  LET d2 == b2 + e2 IN
+  LET a2 == d2 + e2 IN
+  /\ fail = "OK"
+  /\ InBounds(b2, e2, d2, a2)
+  /\ QDef(b2, e2, d2, a2) = qtag
+  /\ b' = b2 /\ e' = e2 /\ d' = d2 /\ a' = a2
+  /\ qtag' = qtag
+  /\ fail' = "OK"
+  /\ lastMove' = "σ"
+
+SigmaFail_OUT_OF_BOUNDS ==
+  LET e2 == e + 1 IN
+  LET b2 == b IN
+  LET d2 == b2 + e2 IN
+  LET a2 == d2 + e2 IN
+  /\ fail = "OK"
+  /\ ~InBounds(b2, e2, d2, a2)
+  /\ UNCHANGED <<b,e,d,a,qtag>>
+  /\ fail' = "OUT_OF_BOUNDS"
+  /\ lastMove' = "σ"
+
+SigmaFail_FIXED_Q ==
+  LET e2 == e + 1 IN
+  LET b2 == b IN
+  LET d2 == b2 + e2 IN
+  LET a2 == d2 + e2 IN
+  /\ fail = "OK"
+  /\ InBounds(b2, e2, d2, a2)
+  /\ QDef(b2, e2, d2, a2) # qtag
+  /\ UNCHANGED <<b,e,d,a,qtag>>
+  /\ fail' = "FIXED_Q_VIOLATION"
+  /\ lastMove' = "σ"
+
+Sigma ==
+  SigmaSucc \/ SigmaFail_OUT_OF_BOUNDS \/ SigmaFail_FIXED_Q
+
+
+(*** μ : swap b <-> e; close tuple canonically ***)
+
+MuSucc ==
+  LET b2 == e IN
+  LET e2 == b IN
+  LET d2 == b2 + e2 IN
+  LET a2 == d2 + e2 IN
+  /\ fail = "OK"
+  /\ InBounds(b2, e2, d2, a2)
+  /\ QDef(b2, e2, d2, a2) = qtag
+  /\ b' = b2 /\ e' = e2 /\ d' = d2 /\ a' = a2
+  /\ qtag' = qtag
+  /\ fail' = "OK"
+  /\ lastMove' = "μ"
+
+MuFail_OUT_OF_BOUNDS ==
+  LET b2 == e IN
+  LET e2 == b IN
+  LET d2 == b2 + e2 IN
+  LET a2 == d2 + e2 IN
+  /\ fail = "OK"
+  /\ ~InBounds(b2, e2, d2, a2)
+  /\ UNCHANGED <<b,e,d,a,qtag>>
+  /\ fail' = "OUT_OF_BOUNDS"
+  /\ lastMove' = "μ"
+
+MuFail_FIXED_Q ==
+  LET b2 == e IN
+  LET e2 == b IN
+  LET d2 == b2 + e2 IN
+  LET a2 == d2 + e2 IN
+  /\ fail = "OK"
+  /\ InBounds(b2, e2, d2, a2)
+  /\ QDef(b2, e2, d2, a2) # qtag
+  /\ UNCHANGED <<b,e,d,a,qtag>>
+  /\ fail' = "FIXED_Q_VIOLATION"
+  /\ lastMove' = "μ"
+
+Mu ==
+  MuSucc \/ MuFail_OUT_OF_BOUNDS \/ MuFail_FIXED_Q
+
+
+(*** λ_k : scale (b,e) by k; close tuple canonically ***)
+
+LambdaSucc ==
+  \E k \in KSet :
+    LET b2 == k * b IN
+    LET e2 == k * e IN
+    LET d2 == b2 + e2 IN
+    LET a2 == d2 + e2 IN
+    /\ fail = "OK"
+    /\ InBounds(b2, e2, d2, a2)
+    /\ QDef(b2, e2, d2, a2) = qtag
+    /\ b' = b2 /\ e' = e2 /\ d' = d2 /\ a' = a2
+    /\ qtag' = qtag
+    /\ fail' = "OK"
+    /\ lastMove' = "λ"
+
+LambdaFail_OUT_OF_BOUNDS ==
+  \E k \in KSet :
+    LET b2 == k * b IN
+    LET e2 == k * e IN
+    LET d2 == b2 + e2 IN
+    LET a2 == d2 + e2 IN
+    /\ fail = "OK"
+    /\ ~InBounds(b2, e2, d2, a2)
+    /\ UNCHANGED <<b,e,d,a,qtag>>
+    /\ fail' = "OUT_OF_BOUNDS"
+    /\ lastMove' = "λ"
+
+LambdaFail_FIXED_Q ==
+  \E k \in KSet :
+    LET b2 == k * b IN
+    LET e2 == k * e IN
+    LET d2 == b2 + e2 IN
+    LET a2 == d2 + e2 IN
+    /\ fail = "OK"
+    /\ InBounds(b2, e2, d2, a2)
+    /\ QDef(b2, e2, d2, a2) # qtag
+    /\ UNCHANGED <<b,e,d,a,qtag>>
+    /\ fail' = "FIXED_Q_VIOLATION"
+    /\ lastMove' = "λ"
+
+Lambda ==
+  LambdaSucc \/ LambdaFail_OUT_OF_BOUNDS \/ LambdaFail_FIXED_Q
+
+
+(*** Global Next ***************************************************************)
+
+Next ==
+  \/ Sigma
+  \/ Mu
+  \/ Lambda
+  \/ /\ fail # "OK" /\ UNCHANGED <<b,e,d,a,qtag,fail,lastMove>>
+     \* absorbing stutter once failure recorded (keeps failure states distinct)
+
+Spec ==
+  Init /\ [][Next]_<<b,e,d,a,qtag,fail,lastMove>>
+
+(*** Invariants ****************************************************************)
+
+Inv_TupleClosed == TupleClosed(b,e,d,a)
+Inv_InBounds    == InBounds(b,e,d,a)
+Inv_QDef        == qtag = QDef(b,e,d,a)
+Inv_FailDomain  == fail \in {"OK","OUT_OF_BOUNDS","FIXED_Q_VIOLATION","ILLEGAL"}
+Inv_MoveDomain  == lastMove \in {"NONE","σ","μ","λ"}
+
+THEOREM Spec => []Inv_TupleClosed
+THEOREM Spec => []Inv_InBounds
+THEOREM Spec => []Inv_QDef
+THEOREM Spec => []Inv_FailDomain
+THEOREM Spec => []Inv_MoveDomain
+
+===============================================================================

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms.cfg
@@ -1,0 +1,15 @@
+CONSTANTS
+  CAP = 20
+  KSet = {2, 3}
+
+INIT Init_ext
+NEXT Next_ext
+
+INVARIANTS
+  Inv_A1_NoZero
+  Inv_A2_DerivedCoords
+  Inv_S1_NoSquareOperator
+  Inv_S2_IntegerState
+  Inv_T1_IntegerPathTime
+  Inv_T2_FirewallRespected
+  Inv_NT_NoObserverFeedback

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms.tla
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms.tla
@@ -1,0 +1,247 @@
+------------------------------ MODULE QuantumArithmeticAxioms ------------------------------
+EXTENDS QuantumArithmetic
+
+(*
+  QuantumArithmeticAxioms.tla — The six QA compliance axioms + Theorem NT
+  as TLA+ temporal invariants.
+  --------------------------------------------------------------------------
+
+  The Quantum Arithmetic (QA) axiom system comprises six compliance
+  rules (A1, A2, S1, S2, T1, T2) plus Theorem NT (Observer Projection
+  Firewall). This module encodes all seven as named invariants over the
+  QARM generator algebra (see QuantumArithmetic.tla), where TLC can
+  verify them against the reachable state graph.
+
+  The six axioms, briefly:
+
+    A1 (No-Zero)         : b, e \in {1..CAP}, never {0..CAP-1}.
+    A2 (Derived Coords)  : d = b+e, a = b+2e are always derived, never
+                           assigned independently.
+    S1 (No ^2 operator)  : Use b*b rather than b^2 (structural; see note
+                           on Inv_S1_NoSquareOperator below).
+    S2 (Integer state)   : b, e, d, a \in Nat. No float state.
+    T1 (Path time)       : QA time = integer path length. No continuous
+                           time variables in QA logic.
+    T2 (Firewall)        : Observer outputs never feed back as QA inputs.
+
+  Theorem NT (Observer Projection Firewall): continuous functions are
+  observer projections ONLY; the continuous-discrete boundary is crossed
+  EXACTLY TWICE per QA trace (input at Init, output at Project).
+
+  Base: EXTENDS QuantumArithmetic (the A1-compliant generator algebra
+  with b, e \in 1..CAP at Init).
+
+  Additions:
+    - Two observer-layer variables (obs_float, obs_cross_count) that
+      model the continuous-discrete boundary.
+    - A Project action that performs the QA-to-observer output crossing.
+    - Seven named invariants, one per axiom. A1, A2, S2, T1, T2, NT are
+      runtime-checkable (TLC verifies). S1 is STRUCTURAL (TLA+ does not
+      expose a `^` operator on the state variables used here; all
+      multiplicative terms are written as b*b / k*b / k*e); see the
+      comment on Inv_S1_NoSquareOperator below.
+
+  Each runtime-checkable invariant has a dedicated non-vacuity spec
+  (QuantumArithmeticAxioms_negative_{A1,A2,S2,T1,T2,NT}.tla) that
+  exhibits a minimal counterexample, proving the invariant actively
+  detects its violation class rather than holding vacuously over the
+  reachable set.
+
+  Primary references:
+    - Lamport, L. (1994). The Temporal Logic of Actions. ACM TOPLAS 16(3),
+      872-923. DOI: 10.1145/177492.177726.
+    - Lamport, L. (2002). Specifying Systems: The TLA+ Language and Tools
+      for Hardware and Software Engineers. Addison-Wesley.
+      ISBN 978-0-321-14306-8.
+
+  See README.md for motivation, module inventory, and reproduction
+  commands with expected state counts.
+*)
+
+(*** Observer-layer variables ****************************************************
+  Theorem NT (Observer Projection Firewall) states that continuous functions
+  are observer projections ONLY; the continuous-discrete boundary is crossed
+  EXACTLY TWICE per QA trace — once at Init (continuous input seed → discrete
+  tuple) and once at Project (discrete tuple → continuous observer output).
+
+  To encode this in TLA+, we introduce two OBSERVER-LAYER variables that sit
+  OUTSIDE the QA-layer state (b, e, d, a, qtag, fail, lastMove):
+    - obs_float: scalar observer state. Takes value 0 at Init (symbolic
+      marker for "input seed, not yet projected"); updated exactly once, by
+      the Project action, to the QA-layer coord `a` at projection time.
+    - obs_cross_count: number of boundary crossings so far. 1 at Init; 2
+      after Project. No trace ever reaches 3.
+
+  Every QA-layer action (σ / μ / λ_k, plus the absorbing-stutter on failure)
+  carries UNCHANGED <<obs_float, obs_cross_count>> by construction of
+  ExtNext. This is the T2 Firewall at the spec level: continuous outputs
+  cannot feed back as QA inputs, because the observer variables are read-only
+  to the QA layer.
+*******************************************************************************)
+
+VARIABLES
+  obs_float,       \* observer-layer scalar
+  obs_cross_count  \* number of observer-boundary crossings so far
+
+obs_vars  == <<obs_float, obs_cross_count>>
+qa_vars   == <<b, e, d, a, qtag, fail, lastMove>>
+ext_vars  == <<b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count>>
+
+\* Observer output domain: bounded to keep TLC tractable; the symbolic value
+\* 0 marks the INIT seed (pre-projection), and 3..3*CAP spans the projection
+\* image of the coord `a` (since a = b + 2e with b, e \in 1..CAP gives
+\* a \in 3..3*CAP).
+ObsDomain == 0..(3 * CAP)
+
+(*** Extended Init *************************************************************)
+
+Init_ext ==
+  /\ Init                        \* inherits A1-corrected QARM Init
+  /\ obs_float = 0               \* boundary cross 1: continuous seed marker
+  /\ obs_cross_count = 1
+
+(*** Project: the QA → observer-layer output crossing **************************)
+
+Project ==
+  /\ obs_cross_count = 1         \* can only project once per trace
+  /\ fail = "OK"                 \* well-defined only on successful QA states
+  /\ obs_float' = a              \* projection of final coord a (image in Nat)
+  /\ obs_cross_count' = 2        \* boundary cross 2: discrete → observer
+  /\ UNCHANGED qa_vars           \* projection does NOT mutate QA-layer state
+
+(*** Post-projection absorbing stutter *****************************************
+  After Project has fired, no further QA moves are permitted. This encodes
+  the temporal half of Theorem NT: once the observer-output crossing has
+  occurred, the discrete state is frozen; any continued QA evolution would
+  require re-entering the discrete layer via a third boundary crossing,
+  which is forbidden.
+*******************************************************************************)
+
+PostProjectStutter ==
+  /\ obs_cross_count = 2
+  /\ UNCHANGED ext_vars
+
+(*** Extended Next *************************************************************
+  Three disjuncts:
+    1. QA_firewalled: a base-spec Next move PLUS UNCHANGED on observer vars.
+       This is where the T2 Firewall is enforced structurally — QA actions
+       cannot modify observer-layer state.
+    2. Project: the output boundary crossing.
+    3. PostProjectStutter: absorbing stutter after Project.
+*******************************************************************************)
+
+QA_firewalled ==
+  /\ obs_cross_count = 1         \* QA evolution only allowed before Project
+  /\ Next                        \* inherited from QuantumArithmetic
+  /\ UNCHANGED obs_vars
+
+Next_ext ==
+  \/ QA_firewalled
+  \/ Project
+  \/ PostProjectStutter
+
+Spec_ext ==
+  Init_ext /\ [][Next_ext]_ext_vars
+
+(*** ---- The Seven Axiom Invariants ---- *************************************
+  One axiom per Inv_* (no conflation per scope discipline). Each invariant
+  has a dedicated non-vacuity negative spec under QAAxioms_negative_*.tla.
+  S1 is structural-only (TLA+ does not expose a `^` operator on our state
+  variables; enforcement is syntactic over module text, not runtime).
+*******************************************************************************)
+
+(*** A1 (No-Zero): states in {1..CAP}, never 0. Operative constraint is on
+     (b, e); derived coords (d, a) then live in {2..3*CAP} and {3..3*CAP}
+     respectively, so a "no-zero" predicate on them is implied but weaker.
+     This invariant checks b and e directly.
+*******************************************************************************)
+
+Inv_A1_NoZero ==
+  /\ b \in 1..CAP
+  /\ e \in 1..CAP
+
+(*** A2 (Derived Coords): d = b+e, a = b+2e — always derived, never assigned
+     independently. The base TupleClosed uses a = d+e, which expands to
+     a = b+2e; we assert both forms explicitly to catch violations that
+     might touch either pathway.
+*******************************************************************************)
+
+Inv_A2_DerivedCoords ==
+  /\ d = b + e
+  /\ a = b + 2 * e
+
+(*** S1 (No `**2`): STRUCTURAL. The spec uses `*` exclusively for squaring
+     and scaling (b*b, k*b, k*e) — there is no `^` operator on state
+     variables in this module or its base QuantumArithmetic. Enforcement
+     of this property is syntactic over module TEXT, not over reachable
+     states; a state-level invariant cannot fully capture "no use of `^2`".
+     The invariant below asserts a trivially-true state predicate that
+     syntactically USES `b*b` (S1-compliant form), locking in the convention
+     at the module level and referencing a state variable so TLC treats it
+     as a genuine state invariant rather than a constant formula. Any
+     future author who introduces `b^2` anywhere must either match this
+     predicate's form OR explicitly override — the diff surfaces the
+     violation. For runtime failure modes use the S2 and A2 invariants
+     (which DO fire on non-Nat or miscomputed values).
+*******************************************************************************)
+
+Inv_S1_NoSquareOperator == b * b >= 0
+
+(*** S2 (No float state): b, e, d, a must be Nat. In TLA+ native numerics
+     are integer; the invariant catches type-domain violations where an
+     action writes a non-Nat value (e.g., string, tuple, function) to a
+     state variable. qtag is also checked for domain soundness.
+*******************************************************************************)
+
+Inv_S2_IntegerState ==
+  /\ b \in Nat
+  /\ e \in Nat
+  /\ d \in Nat
+  /\ a \in Nat
+  /\ qtag \in Nat
+
+(*** T1 (Path Time): QA time = integer path length. lastMove records the
+     most recent generator; its domain is finite and discrete. No
+     continuous time variable `t` is declared in ext_vars. The invariant
+     verifies lastMove membership in the finite move-class alphabet
+     (including "PROJECT" for the extension layer).
+*******************************************************************************)
+
+Inv_T1_IntegerPathTime ==
+  lastMove \in {"NONE","σ","μ","λ"}
+  \* Note: Project intentionally does NOT write to lastMove. It is a
+  \* boundary-crossing action, not a QA generator. lastMove continues to
+  \* record only σ / μ / λ moves, preserving the T1 interpretation of
+  \* "discrete QA path time" as the number of generator firings.
+
+(*** T2 (Firewall): Observer outputs never feed back as QA inputs.
+     Operationalized at the state level: while obs_cross_count = 1 (Project
+     has not yet run), obs_float must retain its Init value (0). Only the
+     Project action may modify obs_float. Any QA action that writes
+     obs_float to a different value violates the spatial firewall.
+*******************************************************************************)
+
+Inv_T2_FirewallRespected ==
+  (obs_cross_count = 1) => (obs_float = 0)
+
+(*** NT (Observer Projection): Boundary crossed EXACTLY twice per trace.
+     obs_cross_count is 1 at Init (input crossing) and reaches 2 at
+     Project (output crossing). It never reaches 3 (no feedback) and
+     never reaches 0 (Init always counts as crossing 1). This is the
+     temporal-counting form of Theorem NT.
+*******************************************************************************)
+
+Inv_NT_NoObserverFeedback ==
+  obs_cross_count \in {1, 2}
+
+(*** Theorems *******************************************************************)
+
+THEOREM Spec_ext => []Inv_A1_NoZero
+THEOREM Spec_ext => []Inv_A2_DerivedCoords
+THEOREM Spec_ext => []Inv_S1_NoSquareOperator
+THEOREM Spec_ext => []Inv_S2_IntegerState
+THEOREM Spec_ext => []Inv_T1_IntegerPathTime
+THEOREM Spec_ext => []Inv_T2_FirewallRespected
+THEOREM Spec_ext => []Inv_NT_NoObserverFeedback
+
+===============================================================================

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_cap24.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_cap24.cfg
@@ -1,0 +1,20 @@
+\* Applied-domain scale of QuantumArithmeticAxioms: CAP=24 (mod-24 QA).
+\* Same spec as QuantumArithmeticAxioms.cfg; only CONSTANTS differ.
+\* Purpose: verify the axiom stack is tractable + sound at the CAP used by
+\* applied QA experiments (mod-24 cosmos/satellite/singularity orbits).
+
+CONSTANTS
+  CAP = 24
+  KSet = {2, 3}
+
+INIT Init_ext
+NEXT Next_ext
+
+INVARIANTS
+  Inv_A1_NoZero
+  Inv_A2_DerivedCoords
+  Inv_S1_NoSquareOperator
+  Inv_S2_IntegerState
+  Inv_T1_IntegerPathTime
+  Inv_T2_FirewallRespected
+  Inv_NT_NoObserverFeedback

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A1.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A1.cfg
@@ -1,0 +1,4 @@
+INIT Init
+NEXT Next
+
+INVARIANT Inv_A1_NoZero

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A1.tla
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A1.tla
@@ -1,0 +1,52 @@
+---------------------- MODULE QuantumArithmeticAxioms_negative_A1 ----------------------
+EXTENDS Naturals, Integers, TLC
+
+(*
+  NEGATIVE TEST for Inv_A1_NoZero.
+
+  Writes b' = 0 directly, violating the A1 (No-Zero) axiom which says
+  QA states live in {1..N}, never {0..N-1}. The Inv_A1_NoZero invariant
+  from QuantumArithmeticAxioms.tla must fire with a ≤3-state
+  counterexample.
+*)
+
+VARIABLES b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count
+
+vars == <<b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count>>
+
+\* Init: a legal A1-compliant state (b=1, e=1 ⇒ d=2, a=3)
+Init ==
+  /\ b = 1
+  /\ e = 1
+  /\ d = 2
+  /\ a = 3
+  /\ qtag = 24 * 3 + 3  \* duo-modular tag for a=3: Phi9(3)=3, Phi24(3)=3
+  /\ fail = "OK"
+  /\ lastMove = "NONE"
+  /\ obs_float = 0
+  /\ obs_cross_count = 1
+
+\* BROKEN ACTION: writes b' = 0, violating A1 (b must be >= 1).
+BrokenA1 ==
+  /\ b' = 0      \* BAD: A1 says b \in 1..CAP, never 0
+  /\ e' = 1
+  /\ d' = 1
+  /\ a' = 2
+  /\ qtag' = qtag
+  /\ fail' = "OK"
+  /\ lastMove' = "σ"
+  /\ UNCHANGED <<obs_float, obs_cross_count>>
+
+Next == BrokenA1
+
+Spec == Init /\ [][Next]_vars
+
+\* Mirror of Inv_A1_NoZero from QuantumArithmeticAxioms.tla. Uses
+\* CAP = 20 implicitly by asserting b \in 1..20 (negative test does not
+\* take CONSTANTS; we hardwire the domain to match
+\* QuantumArithmeticAxioms's bounded-model configuration).
+Inv_A1_NoZero ==
+  /\ b \in 1..20
+  /\ e \in 1..20
+
+================================================================================

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A2.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A2.cfg
@@ -1,0 +1,4 @@
+INIT Init
+NEXT Next
+
+INVARIANT Inv_A2_DerivedCoords

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A2.tla
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A2.tla
@@ -1,0 +1,47 @@
+---------------------- MODULE QuantumArithmeticAxioms_negative_A2 ----------------------
+EXTENDS Naturals, Integers, TLC
+
+(*
+  NEGATIVE TEST for Inv_A2_DerivedCoords.
+
+  Writes d' such that d' != b' + e', violating A2 (Derived Coords):
+  d = b+e, a = b+2e must always be derived from (b,e), never assigned
+  independently. The Inv_A2_DerivedCoords invariant must fire with a
+  ≤3-state counterexample.
+*)
+
+VARIABLES b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count
+
+vars == <<b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count>>
+
+Init ==
+  /\ b = 1
+  /\ e = 1
+  /\ d = 2
+  /\ a = 3
+  /\ qtag = 24 * 3 + 3
+  /\ fail = "OK"
+  /\ lastMove = "NONE"
+  /\ obs_float = 0
+  /\ obs_cross_count = 1
+
+\* BROKEN ACTION: writes d' = 99 while b' + e' = 4. Violates d = b + e.
+BrokenA2 ==
+  /\ b' = 2
+  /\ e' = 2
+  /\ d' = 99     \* BAD: should be b' + e' = 4
+  /\ a' = 6      \* nominally b' + 2*e' = 6 (so a check passes; only d is broken)
+  /\ qtag' = qtag
+  /\ fail' = "OK"
+  /\ lastMove' = "σ"
+  /\ UNCHANGED <<obs_float, obs_cross_count>>
+
+Next == BrokenA2
+
+Spec == Init /\ [][Next]_vars
+
+Inv_A2_DerivedCoords ==
+  /\ d = b + e
+  /\ a = b + 2 * e
+
+================================================================================

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_NT.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_NT.cfg
@@ -1,0 +1,4 @@
+INIT Init
+NEXT Next
+
+INVARIANT Inv_NT_NoObserverFeedback

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_NT.tla
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_NT.tla
@@ -1,0 +1,45 @@
+---------------------- MODULE QuantumArithmeticAxioms_negative_NT ----------------------
+EXTENDS Naturals, Integers, TLC
+
+(*
+  NEGATIVE TEST for Inv_NT_NoObserverFeedback.
+
+  Writes obs_cross_count' = 3, violating the Theorem NT bound that the
+  observer-layer boundary is crossed EXACTLY TWICE per QA trace: once at
+  Init (continuous input seed → discrete) and once at Project (discrete →
+  continuous output). A third crossing represents feedback from observer
+  output back into the QA layer — forbidden by Theorem NT.
+
+  Expected: Inv_NT_NoObserverFeedback violated with a ≤3-state counterexample.
+*)
+
+VARIABLES b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count
+
+vars == <<b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count>>
+
+Init ==
+  /\ b = 1
+  /\ e = 1
+  /\ d = 2
+  /\ a = 3
+  /\ qtag = 24 * 3 + 3
+  /\ fail = "OK"
+  /\ lastMove = "NONE"
+  /\ obs_float = 3           \* represents post-Project state (cross 2 done)
+  /\ obs_cross_count = 2
+
+\* BROKEN ACTION: attempts a THIRD boundary crossing (observer → QA feedback).
+\* NT says the boundary is crossed at most twice; a third crossing means the
+\* observer layer is feeding back into QA as a causal input.
+BrokenNT ==
+  /\ UNCHANGED <<b, e, d, a, qtag, fail, lastMove, obs_float>>
+  /\ obs_cross_count' = 3    \* BAD: NT caps at 2
+
+Next == BrokenNT
+
+Spec == Init /\ [][Next]_vars
+
+Inv_NT_NoObserverFeedback ==
+  obs_cross_count \in {1, 2}
+
+================================================================================

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_S2.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_S2.cfg
@@ -1,0 +1,4 @@
+INIT Init
+NEXT Next
+
+INVARIANT Inv_S2_IntegerState

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_S2.tla
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_S2.tla
@@ -1,0 +1,53 @@
+---------------------- MODULE QuantumArithmeticAxioms_negative_S2 ----------------------
+EXTENDS Naturals, Integers, TLC
+
+(*
+  NEGATIVE TEST for Inv_S2_IntegerState.
+
+  Writes b' to a non-Nat value (a string), violating S2 (No float state):
+  b, e, d, a must be Nat (int or Fraction). No np.zeros, no float.
+  Since TLA+ has no native float type, the canonical S2 violation is
+  writing a non-numeric value to a state variable; TLC's domain check
+  for `\in Nat` fires on strings / tuples / functions alike.
+
+  Expected: Inv_S2_IntegerState violated with a ≤3-state counterexample.
+*)
+
+VARIABLES b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count
+
+vars == <<b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count>>
+
+Init ==
+  /\ b = 1
+  /\ e = 1
+  /\ d = 2
+  /\ a = 3
+  /\ qtag = 24 * 3 + 3
+  /\ fail = "OK"
+  /\ lastMove = "NONE"
+  /\ obs_float = 0
+  /\ obs_cross_count = 1
+
+\* BROKEN ACTION: writes b' = "ghost", violating b \in Nat.
+BrokenS2 ==
+  /\ b' = "ghost"    \* BAD: S2 says b \in Nat
+  /\ e' = 1
+  /\ d' = 2
+  /\ a' = 3
+  /\ qtag' = qtag
+  /\ fail' = "OK"
+  /\ lastMove' = "σ"
+  /\ UNCHANGED <<obs_float, obs_cross_count>>
+
+Next == BrokenS2
+
+Spec == Init /\ [][Next]_vars
+
+Inv_S2_IntegerState ==
+  /\ b \in Nat
+  /\ e \in Nat
+  /\ d \in Nat
+  /\ a \in Nat
+  /\ qtag \in Nat
+
+================================================================================

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T1.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T1.cfg
@@ -1,0 +1,4 @@
+INIT Init
+NEXT Next
+
+INVARIANT Inv_T1_IntegerPathTime

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T1.tla
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T1.tla
@@ -1,0 +1,49 @@
+---------------------- MODULE QuantumArithmeticAxioms_negative_T1 ----------------------
+EXTENDS Naturals, Integers, TLC
+
+(*
+  NEGATIVE TEST for Inv_T1_IntegerPathTime.
+
+  Writes lastMove' to a value OUTSIDE the finite generator alphabet
+  {"NONE","σ","μ","λ"}, simulating the introduction of a continuous-
+  time-like tag into the QA layer. This directly violates T1
+  (Path Time): QA time is integer path length k; no continuous time
+  variables in QA logic.
+
+  Expected: Inv_T1_IntegerPathTime violated with a ≤3-state counterexample.
+*)
+
+VARIABLES b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count
+
+vars == <<b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count>>
+
+Init ==
+  /\ b = 1
+  /\ e = 1
+  /\ d = 2
+  /\ a = 3
+  /\ qtag = 24 * 3 + 3
+  /\ fail = "OK"
+  /\ lastMove = "NONE"
+  /\ obs_float = 0
+  /\ obs_cross_count = 1
+
+\* BROKEN ACTION: writes lastMove' = "t_continuous", violating T1.
+BrokenT1 ==
+  /\ b' = 1
+  /\ e' = 2
+  /\ d' = 3
+  /\ a' = 5
+  /\ qtag' = qtag
+  /\ fail' = "OK"
+  /\ lastMove' = "t_continuous"   \* BAD: T1 says finite generator alphabet only
+  /\ UNCHANGED <<obs_float, obs_cross_count>>
+
+Next == BrokenT1
+
+Spec == Init /\ [][Next]_vars
+
+Inv_T1_IntegerPathTime ==
+  lastMove \in {"NONE","σ","μ","λ"}
+
+================================================================================

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T2.cfg
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T2.cfg
@@ -1,0 +1,4 @@
+INIT Init
+NEXT Next
+
+INVARIANT Inv_T2_FirewallRespected

--- a/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T2.tla
+++ b/specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T2.tla
@@ -1,0 +1,56 @@
+---------------------- MODULE QuantumArithmeticAxioms_negative_T2 ----------------------
+EXTENDS Naturals, Integers, TLC
+
+(*
+  NEGATIVE TEST for Inv_T2_FirewallRespected.
+
+  A pseudo-QA action modifies obs_float while obs_cross_count is still 1
+  (i.e., Project has not yet fired). This violates the T2 Firewall:
+  observer-layer variables must not be mutated by QA-layer actions;
+  only the dedicated Project action may cross the output boundary.
+
+  The direct state-level encoding of Inv_T2_FirewallRespected is:
+    (obs_cross_count = 1) => (obs_float = 0)
+  The broken action writes obs_float' = 42 while obs_cross_count remains 1,
+  so the invariant must fire.
+
+  Expected: ≤3-state counterexample.
+*)
+
+VARIABLES b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count
+
+vars == <<b, e, d, a, qtag, fail, lastMove, obs_float, obs_cross_count>>
+
+Init ==
+  /\ b = 1
+  /\ e = 1
+  /\ d = 2
+  /\ a = 3
+  /\ qtag = 24 * 3 + 3
+  /\ fail = "OK"
+  /\ lastMove = "NONE"
+  /\ obs_float = 0           \* A1-compliant Init
+  /\ obs_cross_count = 1     \* pre-Project
+
+\* BROKEN ACTION: QA-layer pseudo-step that illegally modifies obs_float
+\* without advancing obs_cross_count. Encodes a "continuous output leaks
+\* back as QA state" violation.
+BrokenT2 ==
+  /\ b' = 1
+  /\ e' = 2
+  /\ d' = 3
+  /\ a' = 5
+  /\ qtag' = qtag
+  /\ fail' = "OK"
+  /\ lastMove' = "σ"
+  /\ obs_float' = 42         \* BAD: T2 says QA actions UNCHANGED obs_float
+  /\ obs_cross_count' = 1    \* unchanged: projection not declared
+
+Next == BrokenT2
+
+Spec == Init /\ [][Next]_vars
+
+Inv_T2_FirewallRespected ==
+  (obs_cross_count = 1) => (obs_float = 0)
+
+================================================================================

--- a/specifications/QuantumArithmetic/README.md
+++ b/specifications/QuantumArithmetic/README.md
@@ -1,0 +1,232 @@
+# Quantum Arithmetic — Axiom System as TLA+ Temporal Invariants
+
+A self-contained TLA+ specification of the **Quantum Arithmetic (QA)**
+generator algebra, with its six compliance axioms plus Theorem NT
+(Observer Projection Firewall) encoded as TLA+ temporal invariants over
+the reachable state graph. Each runtime-checkable invariant has a paired
+non-vacuity spec that produces a minimal counterexample, mirroring the
+proof-pair discipline common in the Paxos / distributed-snapshot
+exemplars elsewhere in this corpus.
+
+The package is **self-contained**: no external dependencies beyond the
+TLA+ standard modules (`Naturals`, `Integers`, `TLC`). Reproducing every
+result requires only `tla2tools.jar`.
+
+---
+
+## Why this might be interesting to TLA+ users
+
+1. **First-class failure algebra.** Failures (`OUT_OF_BOUNDS`,
+   `FIXED_Q_VIOLATION`, `ILLEGAL`) are modelled as absorbing-stutter
+   state variables, not silent transition blocks. This gives TLC a
+   concrete way to measure generator-set differentials on a
+   failure-class-by-failure-class basis.
+
+2. **Observer-projection firewall as temporal invariant.** Theorem NT
+   of the QA axiom block asserts that the continuous–discrete
+   boundary is crossed exactly twice per trace (input at `Init`, output
+   at a dedicated `Project` action). This is encoded here with two
+   observer-layer variables (`obs_float`, `obs_cross_count`) and two
+   distinct invariants:
+   - `Inv_T2_FirewallRespected` (spatial firewall — observer state
+     immutable during discrete evolution)
+   - `Inv_NT_NoObserverFeedback` (temporal bound — at most two
+     boundary crossings).
+   To our knowledge this is the first TLA+ encoding of a
+   continuous–discrete firewall as a runtime-checkable property.
+
+3. **Axiom hygiene.** Six of the seven invariants (A1, A2, S2, T1, T2, NT)
+   have dedicated non-vacuity counterexample specs, so the positive
+   result is demonstrably non-vacuous on each axiom. S1 (no `^2`
+   operator on state variables) is structural and documented as such.
+
+4. **Duo-modular packing.** The `qtag = 24 * phi9(a) + phi24(a)` packing
+   puts `qtag` in `[0, 239]` and preserves both the mod-9 and mod-24
+   invariants simultaneously — an efficient hash for TLC's fingerprint
+   set and a research object in its own right.
+
+---
+
+## Background — one-paragraph QA
+
+**Quantum Arithmetic** is a modular-arithmetic framework over pairs
+`(b, e)` with derived coordinates `d = b + e` and `a = b + 2e`. Dynamics
+live in the discrete integer layer; continuous functions enter only as
+**observer projections** at the input and output boundaries. The system
+uses three generator actions:
+
+- **σ** (sigma): `e → e + 1`
+- **μ** (mu):    swap `b ↔ e`
+- **λ_k** (lambda): scale `(b, e) → (k·b, k·e)` for `k ∈ KSet`
+
+Each generator is paired with explicit failure actions (`OUT_OF_BOUNDS`
+when successor exceeds `CAP`, `FIXED_Q_VIOLATION` when successor breaks
+duo-modular invariance). The failure states are absorbing — once in a
+fail state, the tuple is frozen.
+
+The six compliance axioms are:
+
+| Axiom | Rule | Runtime check? |
+|---|---|---|
+| A1 | No-Zero: `b, e ∈ {1..CAP}` | Yes (`Inv_A1_NoZero`) |
+| A2 | Derived Coords: `d = b+e`, `a = b+2e` | Yes (`Inv_A2_DerivedCoords`) |
+| S1 | No `^2` operator; use `b*b` | Structural (module text) |
+| S2 | Integer state: `b, e, d, a ∈ Nat` | Yes (`Inv_S2_IntegerState`) |
+| T1 | Integer path time: discrete generator alphabet only | Yes (`Inv_T1_IntegerPathTime`) |
+| T2 | Firewall: observer outputs don't feed back as QA inputs | Yes (`Inv_T2_FirewallRespected`) |
+
+Plus **Theorem NT** (Observer Projection Firewall): boundary crossed
+exactly twice per trace, encoded as `Inv_NT_NoObserverFeedback`.
+
+---
+
+## Module inventory
+
+| File | Role |
+|---|---|
+| `QuantumArithmetic.tla` | Base generator algebra. σ/μ/λ_k actions + paired failure actions. A1-compliant Init (`b, e ∈ 1..CAP`). |
+| `QuantumArithmetic.cfg` | Bounded model (`CAP = 20`, `KSet = {2, 3}`). |
+| `QuantumArithmeticAxioms.tla` | EXTENDS the base. Adds observer-layer variables (`obs_float`, `obs_cross_count`) + `Project` action + the seven axiom invariants. |
+| `QuantumArithmeticAxioms.cfg` | CAP=20 positive check, all 7 invariants active. |
+| `QuantumArithmeticAxioms_cap24.cfg` | CAP=24 applied-domain scale check (mod-24). |
+| `QuantumArithmeticAxioms_negative_A1.tla` | Non-vacuity: writes `b' = 0`, violates `Inv_A1_NoZero`. |
+| `QuantumArithmeticAxioms_negative_A2.tla` | Non-vacuity: writes `d' ≠ b' + e'`, violates `Inv_A2_DerivedCoords`. |
+| `QuantumArithmeticAxioms_negative_S2.tla` | Non-vacuity: writes `b' = "ghost"` (non-Nat), violates `Inv_S2_IntegerState`. |
+| `QuantumArithmeticAxioms_negative_T1.tla` | Non-vacuity: writes `lastMove' = "t_continuous"` outside alphabet. |
+| `QuantumArithmeticAxioms_negative_T2.tla` | Non-vacuity: writes `obs_float' = 42` during discrete step. |
+| `QuantumArithmeticAxioms_negative_NT.tla` | Non-vacuity: increments `obs_cross_count` past 2. |
+| `QuantumArithmeticAxioms_negative_*.cfg` | Paired configs (one per negative spec). |
+| `LICENSE` | MIT license. |
+| `NOTICE.md` | Attribution notice / requested citation form. |
+
+8 TLA+ modules + 9 configs + 1 README + 1 LICENSE + 1 NOTICE = 20 files
+(plus `manifest.json`).
+
+---
+
+## Reproduction
+
+From this directory, with `tla2tools.jar` on the path (referenced here
+by `$TLA2TOOLS`):
+
+```bash
+# Positive check: all 7 invariants hold over the reachable state graph.
+# Expected: 90 initial states / 470 distinct / depth 3 / 0 errors / ~2 s.
+java -XX:+UseParallelGC -jar $TLA2TOOLS -workers 4 -terse \
+    -config QuantumArithmeticAxioms.cfg QuantumArithmeticAxioms.tla
+
+# Applied-domain scale: same spec, CAP = 24 (mod-24 QA).
+# Expected: 132 initial states / 686 distinct / 0 errors / ~2 s.
+java -XX:+UseParallelGC -jar $TLA2TOOLS -workers 4 -terse \
+    -config QuantumArithmeticAxioms_cap24.cfg QuantumArithmeticAxioms.tla
+
+# Base spec (QARM generator algebra, without axiom layer).
+# Expected: 90 initial states / 374 distinct / 0 errors / ~3 s.
+java -XX:+UseParallelGC -jar $TLA2TOOLS -workers 4 -terse \
+    -config QuantumArithmetic.cfg QuantumArithmetic.tla
+
+# Six non-vacuity checks — each produces a 2-state counterexample
+# for its target invariant.
+for axiom in A1 A2 S2 T1 T2 NT; do
+  echo "=== Non-vacuity: Inv_${axiom} ==="
+  java -XX:+UseParallelGC -jar $TLA2TOOLS -workers 4 -terse \
+      -config QuantumArithmeticAxioms_negative_${axiom}.cfg \
+      QuantumArithmeticAxioms_negative_${axiom}.tla
+done
+```
+
+---
+
+## Expected results
+
+| Spec / Config | States | Depth | Outcome |
+|---|---|---|---|
+| `QuantumArithmetic` @ CAP=20 | 90 init / 374 distinct | 2 | 0 errors (5 base invariants hold) |
+| `QuantumArithmeticAxioms` @ CAP=20 | 90 init / 470 distinct | 3 | 0 errors (all 7 axiom invariants hold) |
+| `QuantumArithmeticAxioms` @ CAP=24 | 132 init / 686 distinct | 3 | 0 errors |
+| `QuantumArithmeticAxioms_negative_A1` | 2 | 2 | `Inv_A1_NoZero` violated (b'=0 counterexample) |
+| `QuantumArithmeticAxioms_negative_A2` | 2 | 2 | `Inv_A2_DerivedCoords` violated (d'=99 ≠ b'+e') |
+| `QuantumArithmeticAxioms_negative_S2` | 2 | 2 | `Inv_S2_IntegerState` fails to evaluate (b'="ghost" — string ∉ Nat) |
+| `QuantumArithmeticAxioms_negative_T1` | 2 | 2 | `Inv_T1_IntegerPathTime` violated (lastMove' out of alphabet) |
+| `QuantumArithmeticAxioms_negative_T2` | 2 | 2 | `Inv_T2_FirewallRespected` violated (obs_float' modified by QA step) |
+| `QuantumArithmeticAxioms_negative_NT` | 2 | 2 | `Inv_NT_NoObserverFeedback` violated (3rd boundary crossing attempted) |
+
+All counterexamples are minimal (Init + 1 step). The wall-time budget on
+a 4-core commodity workstation (OpenJDK 21 + TLC) is under 30 s for
+the full package including the scale test.
+
+**Note on the S2 counterexample.** TLC reports
+`Error: Evaluating invariant Inv_S2_IntegerState failed` (rather than the
+more familiar "Invariant X is violated") because the successor-state
+assignment `b' = "ghost"` produces a state on which the invariant's
+`b \in Nat` predicate is undefined — TLC cannot decide whether a string
+is a natural number. This is the expected outcome for a type-domain
+violation: the invariant fails, but via an evaluation error rather than
+a boolean violation. Either way, the negative spec demonstrates S2 is
+non-vacuous.
+
+---
+
+## Design notes
+
+### Why `EXTENDS` rather than a single monolithic module
+
+`QuantumArithmeticAxioms.tla` `EXTENDS QuantumArithmetic` so that the
+generator algebra and the axiom invariants are separable concerns. This
+matches the upstream convention in `specifications/Paxos/` (where
+`Paxos.tla` composes `Consensus.tla`) and lets the base be reused by
+other extension modules (e.g., alternative axiom systems, or
+domain-specific refinements at larger `CAP`).
+
+### The `Project` action and the observer-layer variables
+
+The base spec has no notion of a continuous/observer layer.
+`QuantumArithmeticAxioms.tla` introduces two variables:
+
+- `obs_float ∈ 0..(3·CAP)` — observer scalar. Set to `0` at `Init`
+  (symbolic "input seed") and updated exactly once by the `Project`
+  action to the current value of the QA coord `a`.
+- `obs_cross_count ∈ {1, 2}` — number of boundary crossings so far.
+  `1` at `Init` (input crossing); `2` after `Project` fires (output
+  crossing). Reaching `3` would indicate observer-layer feedback into
+  the discrete layer, which Theorem NT forbids.
+
+The extended `Next_ext` has three disjuncts:
+
+1. `QA_firewalled`: a base-spec `Next` move PLUS `UNCHANGED <<obs_float,
+   obs_cross_count>>`. Only fires when `obs_cross_count = 1`.
+2. `Project`: the output boundary crossing.
+3. `PostProjectStutter`: absorbing after `Project`.
+
+### Why `Inv_S1_NoSquareOperator` is `b * b >= 0`
+
+TLA+ has no native `^2` or `**` operator on state variables in the
+relevant modules; S1's "no libm-ULP-drift-prone squaring" rule is
+**syntactic** over module text, not a state predicate over reachable
+values. To keep all seven axioms as named invariants in a single
+consistent stack, `Inv_S1_NoSquareOperator` is defined as the trivially
+true state predicate `b * b >= 0`. This locks in the `b*b` convention at
+the module level (any future author introducing `b^2` would diff against
+this predicate) and satisfies TLC's preference for state invariants to
+reference at least one state variable. The S1 enforcement at the *text*
+level is handled by an external linter in the source repo.
+
+---
+
+## References
+
+Primary TLA+ references:
+
+- Lamport, L. (1994). *The Temporal Logic of Actions.* ACM Transactions
+  on Programming Languages and Systems 16(3), 872–923. DOI:
+  [10.1145/177492.177726](https://doi.org/10.1145/177492.177726).
+- Lamport, L. (2002). *Specifying Systems: The TLA+ Language and Tools
+  for Hardware and Software Engineers.* Addison-Wesley.
+  ISBN 978-0-321-14306-8.
+- Cousineau, D., Doligez, D., Lamport, L., Merz, S., Ricketts, D., &
+  Vanzetto, H. (2012). *TLA+ Proofs.* FM 2012 (LNCS 7436), 147–154.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Suggested citation form in
+[`NOTICE.md`](NOTICE.md).

--- a/specifications/QuantumArithmetic/manifest.json
+++ b/specifications/QuantumArithmetic/manifest.json
@@ -1,0 +1,138 @@
+{
+  "sources": [],
+  "authors": [
+    "Will Dale"
+  ],
+  "tags": [],
+  "modules": [
+    {
+      "path": "specifications/QuantumArithmetic/QuantumArithmetic.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmetic.cfg",
+          "runtime": "00:00:03",
+          "mode": "exhaustive search",
+          "result": "success",
+          "distinctStates": 374,
+          "totalStates": 752,
+          "stateDepth": 2
+        }
+      ]
+    },
+    {
+      "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms.cfg",
+          "runtime": "00:00:02",
+          "mode": "exhaustive search",
+          "result": "success",
+          "distinctStates": 470,
+          "totalStates": 944,
+          "stateDepth": 3
+        },
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_cap24.cfg",
+          "runtime": "00:00:02",
+          "mode": "exhaustive search",
+          "result": "success",
+          "distinctStates": 686,
+          "totalStates": 1378,
+          "stateDepth": 3
+        }
+      ]
+    },
+    {
+      "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A1.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A1.cfg",
+          "runtime": "00:00:01",
+          "mode": "exhaustive search",
+          "result": "safety failure",
+          "distinctStates": 2,
+          "totalStates": 2,
+          "stateDepth": 2
+        }
+      ]
+    },
+    {
+      "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A2.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_A2.cfg",
+          "runtime": "00:00:01",
+          "mode": "exhaustive search",
+          "result": "safety failure",
+          "distinctStates": 2,
+          "totalStates": 2,
+          "stateDepth": 2
+        }
+      ]
+    },
+    {
+      "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_S2.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_S2.cfg",
+          "runtime": "00:00:01",
+          "mode": "exhaustive search",
+          "result": "safety failure",
+          "distinctStates": 2,
+          "totalStates": 2,
+          "stateDepth": 2
+        }
+      ]
+    },
+    {
+      "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T1.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T1.cfg",
+          "runtime": "00:00:01",
+          "mode": "exhaustive search",
+          "result": "safety failure",
+          "distinctStates": 2,
+          "totalStates": 2,
+          "stateDepth": 2
+        }
+      ]
+    },
+    {
+      "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T2.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_T2.cfg",
+          "runtime": "00:00:01",
+          "mode": "exhaustive search",
+          "result": "safety failure",
+          "distinctStates": 2,
+          "totalStates": 2,
+          "stateDepth": 2
+        }
+      ]
+    },
+    {
+      "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_NT.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/QuantumArithmetic/QuantumArithmeticAxioms_negative_NT.cfg",
+          "runtime": "00:00:01",
+          "mode": "exhaustive search",
+          "result": "safety failure",
+          "distinctStates": 2,
+          "totalStates": 2,
+          "stateDepth": 2
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Quantum Arithmetic — Axiom System as TLA+ Temporal Invariants

A self-contained TLA+ specification of the **Quantum Arithmetic (QA)**
generator algebra, with its six compliance axioms plus Theorem NT
(Observer Projection Firewall) encoded as TLA+ temporal invariants over
the reachable state graph. Each runtime-checkable invariant has a paired
non-vacuity spec that produces a minimal counterexample, mirroring the
proof-pair discipline common in the Paxos / distributed-snapshot
exemplars elsewhere in this corpus.

The package is **self-contained**: no external dependencies beyond the
TLA+ standard modules (`Naturals`, `Integers`, `TLC`). Reproducing every
result requires only `tla2tools.jar`.

---

## Why this might be interesting to TLA+ users

1. **First-class failure algebra.** Failures (`OUT_OF_BOUNDS`,
   `FIXED_Q_VIOLATION`, `ILLEGAL`) are modelled as absorbing-stutter
   state variables, not silent transition blocks. This gives TLC a
   concrete way to measure generator-set differentials on a
   failure-class-by-failure-class basis.

2. **Observer-projection firewall as temporal invariant.** Theorem NT
   of the QA axiom block asserts that the continuous–discrete
   boundary is crossed exactly twice per trace (input at `Init`, output
   at a dedicated `Project` action). This is encoded here with two
   observer-layer variables (`obs_float`, `obs_cross_count`) and two
   distinct invariants:
   - `Inv_T2_FirewallRespected` (spatial firewall — observer state
     immutable during discrete evolution)
   - `Inv_NT_NoObserverFeedback` (temporal bound — at most two
     boundary crossings).
   To our knowledge this is the first TLA+ encoding of a
   continuous–discrete firewall as a runtime-checkable property.

3. **Axiom hygiene.** Six of the seven invariants (A1, A2, S2, T1, T2, NT)
   have dedicated non-vacuity counterexample specs, so the positive
   result is demonstrably non-vacuous on each axiom. S1 (no `^2`
   operator on state variables) is structural and documented as such.

4. **Duo-modular packing.** The `qtag = 24 * phi9(a) + phi24(a)` packing
   puts `qtag` in `[0, 239]` and preserves both the mod-9 and mod-24
   invariants simultaneously — an efficient hash for TLC's fingerprint
   set and a research object in its own right.

---

## Background — one-paragraph QA

**Quantum Arithmetic** is a modular-arithmetic framework over pairs
`(b, e)` with derived coordinates `d = b + e` and `a = b + 2e`. Dynamics
live in the discrete integer layer; continuous functions enter only as
**observer projections** at the input and output boundaries. The system
uses three generator actions:

- **σ** (sigma): `e → e + 1`
- **μ** (mu):    swap `b ↔ e`
- **λ_k** (lambda): scale `(b, e) → (k·b, k·e)` for `k ∈ KSet`

Each generator is paired with explicit failure actions (`OUT_OF_BOUNDS`
when successor exceeds `CAP`, `FIXED_Q_VIOLATION` when successor breaks
duo-modular invariance). The failure states are absorbing — once in a
fail state, the tuple is frozen.

The six compliance axioms are:

| Axiom | Rule | Runtime check? |
|---|---|---|
| A1 | No-Zero: `b, e ∈ {1..CAP}` | Yes (`Inv_A1_NoZero`) |
| A2 | Derived Coords: `d = b+e`, `a = b+2e` | Yes (`Inv_A2_DerivedCoords`) |
| S1 | No `^2` operator; use `b*b` | Structural (module text) |
| S2 | Integer state: `b, e, d, a ∈ Nat` | Yes (`Inv_S2_IntegerState`) |
| T1 | Integer path time: discrete generator alphabet only | Yes (`Inv_T1_IntegerPathTime`) |
| T2 | Firewall: observer outputs don't feed back as QA inputs | Yes (`Inv_T2_FirewallRespected`) |

Plus **Theorem NT** (Observer Projection Firewall): boundary crossed
exactly twice per trace, encoded as `Inv_NT_NoObserverFeedback`.

---

## Module inventory

| File | Role |
|---|---|
| `QuantumArithmetic.tla` | Base generator algebra. σ/μ/λ_k actions + paired failure actions. A1-compliant Init (`b, e ∈ 1..CAP`). |
| `QuantumArithmetic.cfg` | Bounded model (`CAP = 20`, `KSet = {2, 3}`). |
| `QuantumArithmeticAxioms.tla` | EXTENDS the base. Adds observer-layer variables (`obs_float`, `obs_cross_count`) + `Project` action + the seven axiom invariants. |
| `QuantumArithmeticAxioms.cfg` | CAP=20 positive check, all 7 invariants active. |
| `QuantumArithmeticAxioms_cap24.cfg` | CAP=24 applied-domain scale check (mod-24). |
| `QuantumArithmeticAxioms_negative_A1.tla` | Non-vacuity: writes `b' = 0`, violates `Inv_A1_NoZero`. |
| `QuantumArithmeticAxioms_negative_A2.tla` | Non-vacuity: writes `d' ≠ b' + e'`, violates `Inv_A2_DerivedCoords`. |
| `QuantumArithmeticAxioms_negative_S2.tla` | Non-vacuity: writes `b' = "ghost"` (non-Nat), violates `Inv_S2_IntegerState`. |
| `QuantumArithmeticAxioms_negative_T1.tla` | Non-vacuity: writes `lastMove' = "t_continuous"` outside alphabet. |
| `QuantumArithmeticAxioms_negative_T2.tla` | Non-vacuity: writes `obs_float' = 42` during discrete step. |
| `QuantumArithmeticAxioms_negative_NT.tla` | Non-vacuity: increments `obs_cross_count` past 2. |
| `QuantumArithmeticAxioms_negative_*.cfg` | Paired configs (one per negative spec). |
| `LICENSE` | MIT license. |
| `NOTICE.md` | Attribution notice / requested citation form. |

8 TLA+ modules + 9 configs + 1 README + 1 LICENSE + 1 NOTICE = 20 files
(plus `manifest.json`).

---

## Reproduction

From this directory, with `tla2tools.jar` on the path (referenced here
by `$TLA2TOOLS`):

```bash
# Positive check: all 7 invariants hold over the reachable state graph.
# Expected: 90 initial states / 470 distinct / depth 3 / 0 errors / ~2 s.
java -XX:+UseParallelGC -jar $TLA2TOOLS -workers 4 -terse \
    -config QuantumArithmeticAxioms.cfg QuantumArithmeticAxioms.tla

# Applied-domain scale: same spec, CAP = 24 (mod-24 QA).
# Expected: 132 initial states / 686 distinct / 0 errors / ~2 s.
java -XX:+UseParallelGC -jar $TLA2TOOLS -workers 4 -terse \
    -config QuantumArithmeticAxioms_cap24.cfg QuantumArithmeticAxioms.tla

# Base spec (QARM generator algebra, without axiom layer).
# Expected: 90 initial states / 374 distinct / 0 errors / ~3 s.
java -XX:+UseParallelGC -jar $TLA2TOOLS -workers 4 -terse \
    -config QuantumArithmetic.cfg QuantumArithmetic.tla

# Six non-vacuity checks — each produces a 2-state counterexample
# for its target invariant.
for axiom in A1 A2 S2 T1 T2 NT; do
  echo "=== Non-vacuity: Inv_${axiom} ==="
  java -XX:+UseParallelGC -jar $TLA2TOOLS -workers 4 -terse \
      -config QuantumArithmeticAxioms_negative_${axiom}.cfg \
      QuantumArithmeticAxioms_negative_${axiom}.tla
done
```

---

## Expected results

| Spec / Config | States | Depth | Outcome |
|---|---|---|---|
| `QuantumArithmetic` @ CAP=20 | 90 init / 374 distinct | 2 | 0 errors (5 base invariants hold) |
| `QuantumArithmeticAxioms` @ CAP=20 | 90 init / 470 distinct | 3 | 0 errors (all 7 axiom invariants hold) |
| `QuantumArithmeticAxioms` @ CAP=24 | 132 init / 686 distinct | 3 | 0 errors |
| `QuantumArithmeticAxioms_negative_A1` | 2 | 2 | `Inv_A1_NoZero` violated (b'=0 counterexample) |
| `QuantumArithmeticAxioms_negative_A2` | 2 | 2 | `Inv_A2_DerivedCoords` violated (d'=99 ≠ b'+e') |
| `QuantumArithmeticAxioms_negative_S2` | 2 | 2 | `Inv_S2_IntegerState` fails to evaluate (b'="ghost" — string ∉ Nat) |
| `QuantumArithmeticAxioms_negative_T1` | 2 | 2 | `Inv_T1_IntegerPathTime` violated (lastMove' out of alphabet) |
| `QuantumArithmeticAxioms_negative_T2` | 2 | 2 | `Inv_T2_FirewallRespected` violated (obs_float' modified by QA step) |
| `QuantumArithmeticAxioms_negative_NT` | 2 | 2 | `Inv_NT_NoObserverFeedback` violated (3rd boundary crossing attempted) |

All counterexamples are minimal (Init + 1 step). The wall-time budget on
a 4-core commodity workstation (OpenJDK 21 + TLC) is under 30 s for
the full package including the scale test.

**Note on the S2 counterexample.** TLC reports
`Error: Evaluating invariant Inv_S2_IntegerState failed` (rather than the
more familiar "Invariant X is violated") because the successor-state
assignment `b' = "ghost"` produces a state on which the invariant's
`b \in Nat` predicate is undefined — TLC cannot decide whether a string
is a natural number. This is the expected outcome for a type-domain
violation: the invariant fails, but via an evaluation error rather than
a boolean violation. Either way, the negative spec demonstrates S2 is
non-vacuous.

---

## Design notes

### Why `EXTENDS` rather than a single monolithic module

`QuantumArithmeticAxioms.tla` `EXTENDS QuantumArithmetic` so that the
generator algebra and the axiom invariants are separable concerns. This
matches the upstream convention in `specifications/Paxos/` (where
`Paxos.tla` composes `Consensus.tla`) and lets the base be reused by
other extension modules (e.g., alternative axiom systems, or
domain-specific refinements at larger `CAP`).

### The `Project` action and the observer-layer variables

The base spec has no notion of a continuous/observer layer.
`QuantumArithmeticAxioms.tla` introduces two variables:

- `obs_float ∈ 0..(3·CAP)` — observer scalar. Set to `0` at `Init`
  (symbolic "input seed") and updated exactly once by the `Project`
  action to the current value of the QA coord `a`.
- `obs_cross_count ∈ {1, 2}` — number of boundary crossings so far.
  `1` at `Init` (input crossing); `2` after `Project` fires (output
  crossing). Reaching `3` would indicate observer-layer feedback into
  the discrete layer, which Theorem NT forbids.

The extended `Next_ext` has three disjuncts:

1. `QA_firewalled`: a base-spec `Next` move PLUS `UNCHANGED <<obs_float,
   obs_cross_count>>`. Only fires when `obs_cross_count = 1`.
2. `Project`: the output boundary crossing.
3. `PostProjectStutter`: absorbing after `Project`.

### Why `Inv_S1_NoSquareOperator` is `b * b >= 0`

TLA+ has no native `^2` or `**` operator on state variables in the
relevant modules; S1's "no libm-ULP-drift-prone squaring" rule is
**syntactic** over module text, not a state predicate over reachable
values. To keep all seven axioms as named invariants in a single
consistent stack, `Inv_S1_NoSquareOperator` is defined as the trivially
true state predicate `b * b >= 0`. This locks in the `b*b` convention at
the module level (any future author introducing `b^2` would diff against
this predicate) and satisfies TLC's preference for state invariants to
reference at least one state variable. The S1 enforcement at the *text*
level is handled by an external linter in the source repo.

---

## References

Primary TLA+ references:

- Lamport, L. (1994). *The Temporal Logic of Actions.* ACM Transactions
  on Programming Languages and Systems 16(3), 872–923. DOI:
  [10.1145/177492.177726](https://doi.org/10.1145/177492.177726).
- Lamport, L. (2002). *Specifying Systems: The TLA+ Language and Tools
  for Hardware and Software Engineers.* Addison-Wesley.
  ISBN 978-0-321-14306-8.
- Cousineau, D., Doligez, D., Lamport, L., Merz, S., Ricketts, D., &
  Vanzetto, H. (2012). *TLA+ Proofs.* FM 2012 (LNCS 7436), 147–154.

## License

MIT — see [`LICENSE`](LICENSE). Suggested citation form in
[`NOTICE.md`](NOTICE.md).
