### PR TITLE
CI: record & use max proof runtime

### DIFF
--- a/.github/scripts/generate_manifest.py
+++ b/.github/scripts/generate_manifest.py
@@ -93,7 +93,7 @@ def generate_new_manifest(examples_root, spec_path, spec_name, parser, queries):
                     }
                     for cfg_path in sorted(get_cfg_files(examples_root, tla_path))
                 ]
-            } | ({'proof' : {'runtime': 'unknown'}} if 'proof' in module_features else {})
+            } | ({'proof' : {'maxRuntimeMinutes': 1}} if 'proof' in module_features else {})
             for tla_path, module_features in get_tla_file_features(examples_root, spec_path, parser, queries)
         ]
     }
@@ -133,7 +133,7 @@ def find_corresponding_model(old_model, new_module):
     return models[0] if any(models) else None
 
 def integrate_model_info(old_model, new_model):
-    fields = ['runtime', 'mode', 'result', 'distinctStates', 'totalStates', 'stateDepth']
+    fields = ['runtime', 'mode', 'result', 'distinctStates', 'totalStates', 'stateDepth', 'workers']
     for field in fields:
         if field in old_model:
             new_model[field] = old_model[field]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
+      - name: Install timeout command
+        if: matrix.os == 'macos-latest'
+        run: brew install coreutils
       - name: Download TLA⁺ dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: $SCRIPT_DIR/windows-setup.sh $SCRIPT_DIR $DEPS_DIR false
@@ -146,13 +149,12 @@ jobs:
             | map(select(has("proof")))
             # Failing on Linux
             | map(select(.path != "specifications/LoopInvariance/SumSequence.tla"))
-            # Take too long to check in the CI
-            | map(select(.path != "specifications/byzpaxos/BPConProof.tla"))
-            | map(select(.path != "specifications/tcp/tcp_proof.tla"))
-            | map(.path + "\u0000")
+            # Skip long-running proofs in CI
+            | map(select(.proof.maxRuntimeMinutes <= 5))
+            | map((.proof.maxRuntimeMinutes | tostring) + "\u0000" + .path + "\u0000")
             | join("")' \
-          | xargs --verbose --null --no-run-if-empty -I {TLA_FILE} \
-          time "$DEPS_DIR/tlapm/bin/tlapm" "{TLA_FILE}" -I "$DEPS_DIR/community" --stretch 5
+          | xargs --verbose --null --no-run-if-empty -n 2 \
+          sh -c 'time timeout --signal=KILL "${1}m" "$DEPS_DIR/tlapm/bin/tlapm" "$2" -I "$DEPS_DIR/community" --stretch 5' --
       - name: Smoke-test manifest generation script
         run: |
           python $SCRIPT_DIR/generate_manifest.py \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Steps:
    - Spec authors: a list of people who authored the spec
    - Spec tags:
      - `"beginner"` if your spec is appropriate for TLA⁺ newcomers
-   - Module proof runtime: if module contains formal proofs, record the approximate time necessary to check the proofs with TLAPM on an ordinary workstation; add `"proof" : { "runtime" : "HH:MM:SS" }` to the module fields at the same level as `models`
+   - Module proof runtime: if module contains formal proofs, record the estimated maximum time necessary to check the proofs with TLAPM on an underpowered workstation such as a CI runner machine; add `"proof" : { "maxRuntimeMinutes" : N }` to the module fields at the same level as `models`. If you have a relatively powerful machine this might up to twice the amount of time it takes locally. If your proof completes in only a couple seconds, put 1 for this value.
      - If less than one minute, proof will be checked in its entirety by the CI
    - Model runtime: approximate model runtime on an ordinary workstation, in `"HH:MM:SS"` format
      - If less than 30 seconds, will be run in its entirety by the CI; otherwise will only be smoke-tested for 5 seconds

--- a/manifest-schema.json
+++ b/manifest-schema.json
@@ -29,13 +29,10 @@
           },
           "proof": {
             "type": "object",
-            "required": ["runtime"],
+            "required": ["maxRuntimeMinutes"],
             "additionalProperties": false,
             "properties": {
-              "runtime": {
-                "type": "string",
-                "pattern": "^(([0-9][0-9]:[0-9][0-9]:[0-9][0-9])|unknown)$"
-              }
+              "maxRuntimeMinutes": {"type": "integer"}
             }
           },
           "models": {

--- a/specifications/Bakery-Boulangerie/manifest.json
+++ b/specifications/Bakery-Boulangerie/manifest.json
@@ -13,7 +13,7 @@
       ],
       "models": [],
       "proof": {
-        "runtime": "00:00:20"
+        "maxRuntimeMinutes": 2
       }
     },
     {
@@ -23,7 +23,7 @@
       ],
       "models": [],
       "proof": {
-        "runtime": "00:00:30"
+        "maxRuntimeMinutes": 3
       }
     },
     {

--- a/specifications/CigaretteSmokers/manifest.json
+++ b/specifications/CigaretteSmokers/manifest.json
@@ -39,7 +39,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/CoffeeCan/manifest.json
+++ b/specifications/CoffeeCan/manifest.json
@@ -56,7 +56,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/DieHard/manifest.json
+++ b/specifications/DieHard/manifest.json
@@ -37,6 +37,14 @@
       ]
     },
     {
+      "path": "specifications/DieHard/DieHard_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/DieHard/DieHarder.tla",
       "features": [],
       "models": []
@@ -70,14 +78,6 @@
           "workers": 1
         }
       ]
-    },
-    {
-      "path": "specifications/DieHard/DieHard_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
     }
   ]
 }

--- a/specifications/Disruptor/manifest.json
+++ b/specifications/Disruptor/manifest.json
@@ -20,11 +20,6 @@
       ]
     },
     {
-      "path": "specifications/Disruptor/APRingBuffer.tla",
-      "features": [],
-      "models": []
-    },
-    {
       "path": "specifications/Disruptor/APDisruptor_SPMC.tla",
       "features": [],
       "models": [
@@ -35,6 +30,11 @@
           "result": "success"
         }
       ]
+    },
+    {
+      "path": "specifications/Disruptor/APRingBuffer.tla",
+      "features": [],
+      "models": []
     },
     {
       "path": "specifications/Disruptor/Disruptor_MPMC.tla",

--- a/specifications/FiniteMonotonic/manifest.json
+++ b/specifications/FiniteMonotonic/manifest.json
@@ -50,7 +50,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {

--- a/specifications/KeyValueStore/manifest.json
+++ b/specifications/KeyValueStore/manifest.json
@@ -29,6 +29,14 @@
       "models": []
     },
     {
+      "path": "specifications/KeyValueStore/KeyValueStore_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/KeyValueStore/MCKVS.tla",
       "features": [],
       "models": [
@@ -68,14 +76,6 @@
       "path": "specifications/KeyValueStore/Util.tla",
       "features": [],
       "models": []
-    },
-    {
-      "path": "specifications/KeyValueStore/KeyValueStore_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
     }
   ]
 }

--- a/specifications/LearnProofs/manifest.json
+++ b/specifications/LearnProofs/manifest.json
@@ -14,7 +14,7 @@
       ],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -24,7 +24,7 @@
       ],
       "models": [],
       "proof": {
-        "runtime": "00:00:10"
+        "maxRuntimeMinutes": 1
       }
     },
     {

--- a/specifications/LoopInvariance/manifest.json
+++ b/specifications/LoopInvariance/manifest.json
@@ -16,7 +16,7 @@
       ],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -56,7 +56,7 @@
       ],
       "models": [],
       "proof": {
-        "runtime": "00:05:00"
+        "maxRuntimeMinutes": 10
       }
     },
     {
@@ -66,7 +66,7 @@
       ],
       "models": [],
       "proof": {
-        "runtime": "00:01:30"
+        "maxRuntimeMinutes": 3
       }
     }
   ]

--- a/specifications/Majority/manifest.json
+++ b/specifications/Majority/manifest.json
@@ -37,7 +37,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/MisraReachability/manifest.json
+++ b/specifications/MisraReachability/manifest.json
@@ -85,7 +85,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -98,7 +98,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -118,7 +118,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/MissionariesAndCannibals/manifest.json
+++ b/specifications/MissionariesAndCannibals/manifest.json
@@ -36,7 +36,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/MultiCarElevator/manifest.json
+++ b/specifications/MultiCarElevator/manifest.json
@@ -54,7 +54,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/Paxos/manifest.json
+++ b/specifications/Paxos/manifest.json
@@ -10,7 +10,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -68,7 +68,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/PaxosHowToWinATuringAward/manifest.json
+++ b/specifications/PaxosHowToWinATuringAward/manifest.json
@@ -12,7 +12,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -76,7 +76,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -84,7 +84,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/ReadersWriters/manifest.json
+++ b/specifications/ReadersWriters/manifest.json
@@ -42,7 +42,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/SlidingPuzzles/manifest.json
+++ b/specifications/SlidingPuzzles/manifest.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "specifications/SlidingPuzzles/SlidingPuzzles_anim.tla",
-      "features": [ ],
+      "features": [],
       "models": [
         {
           "path": "specifications/SlidingPuzzles/SlidingPuzzles_anim.cfg",

--- a/specifications/SpanningTree/manifest.json
+++ b/specifications/SpanningTree/manifest.json
@@ -70,7 +70,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/SpecifyingSystems/manifest.json
+++ b/specifications/SpecifyingSystems/manifest.json
@@ -111,6 +111,14 @@
       ]
     },
     {
+      "path": "specifications/SpecifyingSystems/AsynchronousInterface/AsynchInterface_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/SpecifyingSystems/AsynchronousInterface/Channel.tla",
       "features": [],
       "models": [
@@ -124,6 +132,14 @@
           "stateDepth": 2
         }
       ]
+    },
+    {
+      "path": "specifications/SpecifyingSystems/AsynchronousInterface/Channel_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
     },
     {
       "path": "specifications/SpecifyingSystems/AsynchronousInterface/PrintValues.tla",
@@ -144,6 +160,14 @@
       "path": "specifications/SpecifyingSystems/CachingMemory/InternalMemory.tla",
       "features": [],
       "models": []
+    },
+    {
+      "path": "specifications/SpecifyingSystems/CachingMemory/InternalMemory_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
     },
     {
       "path": "specifications/SpecifyingSystems/CachingMemory/MCInternalMemory.tla",
@@ -235,6 +259,14 @@
       "models": []
     },
     {
+      "path": "specifications/SpecifyingSystems/Composing/Channel_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/SpecifyingSystems/Composing/CompositeFIFO.tla",
       "features": [],
       "models": []
@@ -245,9 +277,25 @@
       "models": []
     },
     {
+      "path": "specifications/SpecifyingSystems/Composing/HourClock_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/SpecifyingSystems/Composing/InternalMemory.tla",
       "features": [],
       "models": []
+    },
+    {
+      "path": "specifications/SpecifyingSystems/Composing/InternalMemory_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
     },
     {
       "path": "specifications/SpecifyingSystems/Composing/JointActionMemory.tla",
@@ -313,6 +361,14 @@
       "models": []
     },
     {
+      "path": "specifications/SpecifyingSystems/FIFO/Channel_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/SpecifyingSystems/FIFO/FIFO.tla",
       "features": [],
       "models": []
@@ -326,6 +382,14 @@
       "path": "specifications/SpecifyingSystems/FIFO/InnerFIFOInstanced.tla",
       "features": [],
       "models": []
+    },
+    {
+      "path": "specifications/SpecifyingSystems/FIFO/InnerFIFO_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
     },
     {
       "path": "specifications/SpecifyingSystems/FIFO/MCInnerFIFO.tla",
@@ -397,6 +461,14 @@
       ]
     },
     {
+      "path": "specifications/SpecifyingSystems/HourClock/HourClock_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/SpecifyingSystems/Liveness/APHourClock.tla",
       "features": [],
       "models": [
@@ -426,9 +498,25 @@
       "models": []
     },
     {
+      "path": "specifications/SpecifyingSystems/Liveness/HourClock_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/SpecifyingSystems/Liveness/InternalMemory.tla",
       "features": [],
       "models": []
+    },
+    {
+      "path": "specifications/SpecifyingSystems/Liveness/InternalMemory_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
     },
     {
       "path": "specifications/SpecifyingSystems/Liveness/LiveHourClock.tla",
@@ -511,9 +599,25 @@
       "models": []
     },
     {
+      "path": "specifications/SpecifyingSystems/RealTime/HourClock_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/SpecifyingSystems/RealTime/InternalMemory.tla",
       "features": [],
       "models": []
+    },
+    {
+      "path": "specifications/SpecifyingSystems/RealTime/InternalMemory_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
     },
     {
       "path": "specifications/SpecifyingSystems/RealTime/MCRealTime.tla",
@@ -653,6 +757,14 @@
       "models": []
     },
     {
+      "path": "specifications/SpecifyingSystems/TLC/AlternatingBit_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/SpecifyingSystems/TLC/BNFGrammars.tla",
       "features": [],
       "models": []
@@ -676,118 +788,6 @@
           "stateDepth": 10
         }
       ]
-    },
-    {
-      "path": "specifications/SpecifyingSystems/AsynchronousInterface/AsynchInterface_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/AsynchronousInterface/Channel_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/CachingMemory/InternalMemory_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/Composing/Channel_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/Composing/HourClock_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/Composing/InternalMemory_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/FIFO/Channel_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/FIFO/InnerFIFO_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/HourClock/HourClock_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/Liveness/HourClock_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/Liveness/InternalMemory_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/RealTime/HourClock_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/RealTime/InternalMemory_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/SpecifyingSystems/TLC/AlternatingBit_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
     }
   ]
 }

--- a/specifications/TLC/manifest.json
+++ b/specifications/TLC/manifest.json
@@ -6,13 +6,6 @@
   "tags": [],
   "modules": [
     {
-      "path": "specifications/TLC/TLCMC.tla",
-      "features": [
-        "pluscal"
-      ],
-      "models": []
-    },
-    {
       "path": "specifications/TLC/MCReachability.tla",
       "features": [],
       "models": []
@@ -20,6 +13,13 @@
     {
       "path": "specifications/TLC/StateGraphs.tla",
       "features": [],
+      "models": []
+    },
+    {
+      "path": "specifications/TLC/TLCMC.tla",
+      "features": [
+        "pluscal"
+      ],
       "models": []
     },
     {

--- a/specifications/TeachingConcurrency/manifest.json
+++ b/specifications/TeachingConcurrency/manifest.json
@@ -26,7 +26,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -46,7 +46,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -54,7 +54,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -62,7 +62,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/TwoPhase/manifest.json
+++ b/specifications/TwoPhase/manifest.json
@@ -31,7 +31,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -39,7 +39,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/acp/manifest.json
+++ b/specifications/acp/manifest.json
@@ -9,18 +9,6 @@
   "tags": [],
   "modules": [
     {
-      "path": "specifications/acp/APACP_SB.tla",
-      "features": [],
-      "models": [
-        {
-          "path": "specifications/acp/APACP_SB.cfg",
-          "runtime": "00:00:10",
-          "mode": "symbolic",
-          "result": "success"
-        }
-      ]
-    },
-    {
       "path": "specifications/acp/ACP_NB.tla",
       "features": [],
       "models": []
@@ -69,6 +57,18 @@
           "distinctStates": 54944,
           "totalStates": 218352,
           "stateDepth": 21
+        }
+      ]
+    },
+    {
+      "path": "specifications/acp/APACP_SB.tla",
+      "features": [],
+      "models": [
+        {
+          "path": "specifications/acp/APACP_SB.cfg",
+          "runtime": "00:00:10",
+          "mode": "symbolic",
+          "result": "success"
         }
       ]
     }

--- a/specifications/allocator/manifest.json
+++ b/specifications/allocator/manifest.json
@@ -21,6 +21,14 @@
       ]
     },
     {
+      "path": "specifications/allocator/AllocatorImplementation_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 2
+      }
+    },
+    {
       "path": "specifications/allocator/AllocatorRefinement.tla",
       "features": [],
       "models": [
@@ -51,6 +59,14 @@
       ]
     },
     {
+      "path": "specifications/allocator/SchedulingAllocator_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 2
+      }
+    },
+    {
       "path": "specifications/allocator/SimpleAllocator.tla",
       "features": [],
       "models": [
@@ -66,27 +82,11 @@
       ]
     },
     {
-      "path": "specifications/allocator/AllocatorImplementation_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/allocator/SchedulingAllocator_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
       "path": "specifications/allocator/SimpleAllocator_proof.tla",
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/barriers/manifest.json
+++ b/specifications/barriers/manifest.json
@@ -51,7 +51,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:02:00"
+        "maxRuntimeMinutes": 10
       }
     }
   ]

--- a/specifications/bcastByz/manifest.json
+++ b/specifications/bcastByz/manifest.json
@@ -31,7 +31,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:01:15"
+        "maxRuntimeMinutes": 5
       }
     }
   ]

--- a/specifications/byihive/manifest.json
+++ b/specifications/byihive/manifest.json
@@ -55,6 +55,14 @@
       ]
     },
     {
+      "path": "specifications/byihive/VoucherLifeCycle_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/byihive/VoucherRedeem.tla",
       "features": [],
       "models": [
@@ -83,14 +91,6 @@
           "stateDepth": 11
         }
       ]
-    },
-    {
-      "path": "specifications/byihive/VoucherLifeCycle_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
     }
   ]
 }

--- a/specifications/byzpaxos/manifest.json
+++ b/specifications/byzpaxos/manifest.json
@@ -23,7 +23,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:10:00"
+        "maxRuntimeMinutes": 45
       }
     },
     {
@@ -43,7 +43,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -60,7 +60,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -80,7 +80,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:01:15"
+        "maxRuntimeMinutes": 3
       }
     }
   ]

--- a/specifications/dag-consensus/manifest.json
+++ b/specifications/dag-consensus/manifest.json
@@ -1,6 +1,10 @@
 {
-  "sources": ["https://github.com/nano-o/dag-consensus"],
-  "authors": ["Giuliano Losa"],
+  "sources": [
+    "https://github.com/nano-o/dag-consensus"
+  ],
+  "authors": [
+    "Giuliano Losa"
+  ],
   "tags": [],
   "modules": [
     {

--- a/specifications/ewd687a/manifest.json
+++ b/specifications/ewd687a/manifest.json
@@ -39,6 +39,14 @@
       ]
     },
     {
+      "path": "specifications/ewd687a/EWD687a_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 3
+      }
+    },
+    {
       "path": "specifications/ewd687a/MCEWD687a.tla",
       "features": [],
       "models": [
@@ -49,14 +57,6 @@
           "result": "success"
         }
       ]
-    },
-    {
-      "path": "specifications/ewd687a/EWD687a_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
     }
   ]
 }

--- a/specifications/ewd840/manifest.json
+++ b/specifications/ewd840/manifest.json
@@ -84,7 +84,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:10"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -107,7 +107,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/ewd998/manifest.json
+++ b/specifications/ewd998/manifest.json
@@ -28,7 +28,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -135,6 +135,14 @@
       ]
     },
     {
+      "path": "specifications/ewd998/EWD998PCal_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 10
+      }
+    },
+    {
       "path": "specifications/ewd998/EWD998_anim.tla",
       "features": [],
       "models": []
@@ -154,7 +162,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:05:00"
+        "maxRuntimeMinutes": 2
       }
     },
     {
@@ -199,14 +207,6 @@
       "path": "specifications/ewd998/Utils.tla",
       "features": [],
       "models": []
-    },
-    {
-      "path": "specifications/ewd998/EWD998PCal_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
     }
   ]
 }

--- a/specifications/glowingRaccoon/manifest.json
+++ b/specifications/glowingRaccoon/manifest.json
@@ -45,6 +45,14 @@
       ]
     },
     {
+      "path": "specifications/glowingRaccoon/clean_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
+    },
+    {
       "path": "specifications/glowingRaccoon/product.tla",
       "features": [],
       "models": [
@@ -75,19 +83,11 @@
       ]
     },
     {
-      "path": "specifications/glowingRaccoon/clean_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
       "path": "specifications/glowingRaccoon/stages_proof.tla",
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/lamport_mutex/manifest.json
+++ b/specifications/lamport_mutex/manifest.json
@@ -27,7 +27,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:05:00"
+        "maxRuntimeMinutes": 5
       }
     },
     {

--- a/specifications/locks_auxiliary_vars/manifest.json
+++ b/specifications/locks_auxiliary_vars/manifest.json
@@ -24,7 +24,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     },
     {
@@ -42,7 +42,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:00:30"
+        "maxRuntimeMinutes": 2
       }
     },
     {
@@ -62,7 +62,7 @@
         }
       ],
       "proof": {
-        "runtime": "00:00:30"
+        "maxRuntimeMinutes": 1
       }
     },
     {

--- a/specifications/spanning/manifest.json
+++ b/specifications/spanning/manifest.json
@@ -41,7 +41,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/sums_even/manifest.json
+++ b/specifications/sums_even/manifest.json
@@ -27,7 +27,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:00:01"
+        "maxRuntimeMinutes": 1
       }
     }
   ]

--- a/specifications/tcp/manifest.json
+++ b/specifications/tcp/manifest.json
@@ -20,6 +20,11 @@
       ]
     },
     {
+      "path": "specifications/tcp/IndInv_apa.tla",
+      "features": [],
+      "models": []
+    },
+    {
       "path": "specifications/tcp/MCtcp.tla",
       "features": [],
       "models": [
@@ -35,11 +40,6 @@
       ]
     },
     {
-      "path": "specifications/tcp/IndInv_apa.tla",
-      "features": [],
-      "models": []
-    },
-    {
       "path": "specifications/tcp/tcp.tla",
       "features": [],
       "models": []
@@ -49,7 +49,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "00:51:00"
+        "maxRuntimeMinutes": 60
       }
     }
   ]

--- a/specifications/transaction_commit/manifest.json
+++ b/specifications/transaction_commit/manifest.json
@@ -56,6 +56,14 @@
       ]
     },
     {
+      "path": "specifications/transaction_commit/PaxosCommit_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 5
+      }
+    },
+    {
       "path": "specifications/transaction_commit/TCommit.tla",
       "features": [],
       "models": [
@@ -69,6 +77,14 @@
           "stateDepth": 7
         }
       ]
+    },
+    {
+      "path": "specifications/transaction_commit/TCommit_proof.tla",
+      "features": [],
+      "models": [],
+      "proof": {
+        "maxRuntimeMinutes": 1
+      }
     },
     {
       "path": "specifications/transaction_commit/TwoPhase.tla",
@@ -86,27 +102,11 @@
       ]
     },
     {
-      "path": "specifications/transaction_commit/PaxosCommit_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
-      "path": "specifications/transaction_commit/TCommit_proof.tla",
-      "features": [],
-      "models": [],
-      "proof": {
-        "runtime": "unknown"
-      }
-    },
-    {
       "path": "specifications/transaction_commit/TwoPhase_proof.tla",
       "features": [],
       "models": [],
       "proof": {
-        "runtime": "unknown"
+        "maxRuntimeMinutes": 1
       }
     }
   ]


### PR DESCRIPTION
It would be nice to filter the proofs based on their maximum runtime to see whether they should be run in the CI. While the manifest records HH:MM:SS "average" runtime for TLC & Apalache models, this does not make a lot of sense across so many possible machines. Thus we are trying a new approach with the proofs, where we just record the maximum number of minutes we would expect the proof to take to check on any machine that can reasonably run TLAPM. We can then easily filter on this value with `jq` to avoid checking long-running proofs in the CI. This maximum time parameter is passed to the bash `timeout` command which will fail the CI if checking the proof exceeds the given number of minutes.

@lemmy suggested just having a `check_in_ci` flag in the manifest instead, which I did consider, but I think probably the CI here would want to run a greater set of proofs than the CI in the tlaplus/tlapm repo so would like to support filtering based on runtime in this way. In general I think it also seems like a better architecture to not tie manifest fields so closely to whatever tool would want to consume them.

If this maxRuntimeMinutes approach is found to be a decent idea then probably we can change the model-checking process to switch to it as well.

Ref https://github.com/tlaplus/tlapm/pull/273 #171