### PR TITLE
CI: check proofs with --strict

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -149,8 +149,35 @@ jobs:
             | map(select(has("proof")))
             # Failing on Linux
             | map(select(.path != "specifications/LoopInvariance/SumSequence.tla"))
+            # Proofs with steps that carry no proof; --strict reports these as
+            # incomplete (exit 11), so they are checked without it below.
+            | map(select(.path != "specifications/Paxos/Voting.tla"))
+            | map(select(.path != "specifications/PaxosHowToWinATuringAward/Voting.tla"))
+            | map(select(.path != "specifications/byzpaxos/PConProof.tla"))
+            | map(select(.path != "specifications/allocator/AllocatorImplementation_proof.tla"))
+            | map(select(.path != "specifications/MultiCarElevator/Elevator_proof.tla"))
             # Skip long-running proofs in CI
             | map(select(.proof.maxRuntimeMinutes <= 5))
+            | map((.proof.maxRuntimeMinutes | tostring) + "\u0000" + .path + "\u0000")
+            | join("")' \
+          | xargs --verbose --null --no-run-if-empty -n 2 \
+          sh -c 'time timeout --signal=KILL "${1}m" "$DEPS_DIR/tlapm/bin/tlapm" --strict "$2" -I "$DEPS_DIR/community" --stretch 5' --
+      - name: Check proofs with incomplete steps
+        if: matrix.os != 'windows-latest' && !matrix.unicode
+        run: |
+          set -o pipefail
+          find specifications -iname "manifest.json" -print0 \
+          | xargs --null --no-run-if-empty \
+          jq --join-output '
+            .modules
+            | map(select(has("proof")))
+            | map(select(.proof.maxRuntimeMinutes <= 5))
+            | map(select(
+                  .path == "specifications/Paxos/Voting.tla"
+               or .path == "specifications/PaxosHowToWinATuringAward/Voting.tla"
+               or .path == "specifications/byzpaxos/PConProof.tla"
+               or .path == "specifications/allocator/AllocatorImplementation_proof.tla"
+               or .path == "specifications/MultiCarElevator/Elevator_proof.tla"))
             | map((.proof.maxRuntimeMinutes | tostring) + "\u0000" + .path + "\u0000")
             | join("")' \
           | xargs --verbose --null --no-run-if-empty -n 2 \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -151,10 +151,16 @@ jobs:
             | map(select(.path != "specifications/LoopInvariance/SumSequence.tla"))
             # Proofs with steps that carry no proof; --strict reports these as
             # incomplete (exit 11), so they are checked without it below.
+            # Voting/PConProof: steps left open deliberately.
             | map(select(.path != "specifications/Paxos/Voting.tla"))
             | map(select(.path != "specifications/PaxosHowToWinATuringAward/Voting.tla"))
             | map(select(.path != "specifications/byzpaxos/PConProof.tla"))
+            # AllocatorImplementation: blocked on referring to facts derived in
+            # instantiated modules; deferred until that part of the PM is
+            # reimplemented.
             | map(select(.path != "specifications/allocator/AllocatorImplementation_proof.tla"))
+            # Elevator: blocked on the PM not handling definitions of the form
+            # [x \in S, y \in T |-> e(x,y)].
             | map(select(.path != "specifications/MultiCarElevator/Elevator_proof.tla"))
             # Skip long-running proofs in CI
             | map(select(.proof.maxRuntimeMinutes <= 5))


### PR DESCRIPTION
Follows up on tlaplus/CommunityModules#128, where @lemmy suggested the same change here.

`tlapm` exits 0 when a proof step carries no proof at all — such steps generate no obligation, so they never appear in the count and the job passes over a proof that did not close. `--strict` (tlaplus/tlapm#278) reports this as exit 11.

I measured it against current `master` rather than assuming. Of the 67 proof modules this job runs, **62 are unaffected**. Five change:

| module | plain | `--strict` | tlapm summary |
|---|---|---|---|
| `Paxos/Voting.tla` | 0 | **11** | All 7 obligations proved |
| `PaxosHowToWinATuringAward/Voting.tla` | 0 | **11** | All 9 obligations proved |
| `byzpaxos/PConProof.tla` | 0 | **11** | All 10 obligations proved |
| `allocator/AllocatorImplementation_proof.tla` | 0 | **11** | All 195 obligations proved |
| `MultiCarElevator/Elevator_proof.tla` | 0 | **11** | All 223 obligations proved |

(`ewd998/EWD998_proof.tla` was a sixth until #218.)

Rather than skip those five outright, they are checked in a separate step without the flag, mirroring the existing `SumSequence.tla` exclusion. That way they are still verified, and the list of proofs with open steps is visible in the workflow rather than implied.

@muenchnerkindl noted on the other thread that most of these omissions are deliberate — teaching material where leaving the interesting step open is the point. Two of them do not obviously read that way to me, though: `allocator/AllocatorImplementation_proof.tla` (195 obligations) and `MultiCarElevator/Elevator_proof.tla` (223). If either is unintentional I would be glad to look at it the way #218 went; if they are all deliberate, the split above is simply documentation.

Measurement run, both invocations for all 67 modules: https://github.com/vasilisnasopoulos-stack/vortex-dse-cslot-proofs/actions/runs/30840318792
