### PR TITLE
ewd998: raise EWD998_proof budget from 4 to 6 minutes

### DIFF
--- a/specifications/ewd998/manifest.json
+++ b/specifications/ewd998/manifest.json
@@ -162,7 +162,7 @@
       "features": [],
       "models": [],
       "proof": {
-        "maxRuntimeMinutes": 4
+        "maxRuntimeMinutes": 6
       }
     },
     {


### PR DESCRIPTION
The 4-minute budget I set in #218 is marginal on the macOS runners: it passes most of the time, and was killed at the wall in [this run](https://github.com/tlaplus/Examples/actions/runs/31000876116).

```
54195 Killed: 9  timeout --signal=KILL 4m ... EWD998_proof.tla
```

The proof itself is unaffected — the other five jobs in the same run proved it. Measured locally (tlapm 4600b24, `--stretch 5`): **86 seconds, all 850 obligations proved**.

`CONTRIBUTING.md` suggests budgeting up to twice the local time on a fast machine, which is where 4 came from. The macOS runner needed more than 2.8x. Six minutes gives roughly 4x local headroom, which should stop this recurring.

Noticed because it surfaced as an unrelated failure on #220.
