### PR TITLE
CI: fix the guard that skips Apalache on Unicode specs

### DIFF
--- a/.github/scripts/check_small_models.py
+++ b/.github/scripts/check_small_models.py
@@ -41,7 +41,9 @@ def check_model(module, model, expected_runtime):
     module_path = tla_utils.from_cwd(examples_root, module['path'])
     model_path = tla_utils.from_cwd(examples_root, model['path'])
     logging.info(model_path)
-    hard_timeout_in_seconds = 60
+    # Apalache pays for JVM and solver startup before the bounded check
+    # begins, so symbolic models need more room than TLC ones.
+    hard_timeout_in_seconds = 120 if model['mode'] == 'symbolic' else 60
     start_time = timer()
     tlc_result = tla_utils.check_model(
         tools_jar_path,

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,7 +117,7 @@ jobs:
           # Apalache does not yet support Unicode specs:
           # https://github.com/apalache-mc/apalache/issues/2995
           APALACHE_FLAG=()
-          if [ ${{ matrix.unicode }} ]; then
+          if [[ "${{ matrix.unicode }}" == 'true' ]]; then
             APALACHE_FLAG+=("--skip_apalache")
           fi
           python $SCRIPT_DIR/check_small_models.py                       \


### PR DESCRIPTION
## Summary

`if [ ${{ matrix.unicode }} ]` in the "Check small models" step is a single-argument test that asks whether its argument is a non-empty string. Both `true` and `false` are non-empty, so `--skip_apalache` has been passed in every matrix job since 38f89e1 introduced it on 2026-04-25. f1aaf96 noted the same truthiness on the same day but only fixed the Windows launcher that it had been masking.

Consequently no small symbolic model has ever been checked by CI. Of the 46 symbolic models in the manifests, only `EinsteinRiddle/Einstein.cfg` predates the flag, and before then the same guard was unconditionally skipping it by name.

The only Apalache that CI exercised are the two symbolic models above the 30 second threshold, `APFlashWithMutex` and `APGermanData`, which go to `smoke_test_large_models.py`. That script has no `--skip_apalache` option, allows five seconds, and counts `TimeoutExpired` as success. A working Apalache always times out and passes; a broken one exits immediately and fails. That is why Apalache raising its minimum JVM was caught while the model checking itself stayed dormant.

## Test plan

Draft on purpose. This is being opened to find out what happens when 44 Apalache models run in CI for the first time, in particular:

- [ ] Whether the recorded `00:00:01` runtimes are realistic, given that Apalache's JVM startup alone exceeds that; models over the 60 second hard timeout are reported as failures by `check_small_models.py`
- [ ] Whether the Windows `apalache-mc.bat` routing from f1aaf96 works, since it has never executed
- [ ] How much wall-clock time the ASCII jobs gain