### PR TITLE
CI: cut the Actions bill by about a third

### DIFF
--- a/.github/scripts/check_small_models.py
+++ b/.github/scripts/check_small_models.py
@@ -23,6 +23,7 @@ parser.add_argument('--only', nargs='+', help='If provided, only check models in
 parser.add_argument('--verbose', help='Set logging output level to debug', action='store_true')
 parser.add_argument('--enable_assertions', help='Enable Java assertions (pass -enableassertions to JVM)', action='store_true')
 parser.add_argument('--skip_apalache', help='Skip all symbolic (Apalache) models; useful when running against Unicode specs since Apalache does not yet support Unicode (https://github.com/apalache-mc/apalache/issues/2995)', action='store_true')
+parser.add_argument('--representative_sample', help='Check only the fastest model per combination of module features and run mode, instead of every model', action='store_true')
 args = parser.parse_args()
 
 logging.basicConfig(level = logging.DEBUG if args.verbose else logging.INFO)
@@ -36,6 +37,7 @@ skip_models = args.skip
 only_models = args.only
 enable_assertions = args.enable_assertions
 skip_apalache = args.skip_apalache
+representative_sample = args.representative_sample
 
 def check_model(module, model, expected_runtime):
     module_path = tla_utils.from_cwd(examples_root, module['path'])
@@ -94,25 +96,53 @@ def check_model(module, model, expected_runtime):
             logging.error(f'Unhandled TLC result type {type(tlc_result)}: {tlc_result}')
             return False
 
-# Ensure longest-running modules go first
+def coverage_class(module, model):
+    """
+    The kind of coverage a model contributes: which TLA+ constructs the tools
+    have to handle, and how TLC is driven. Models within one class exercise
+    the same code paths, so a single member stands in for all of them.
+    """
+    mode = model['mode']
+    return (
+        frozenset(module['features']),
+        'proof' in module,
+        next(iter(mode)) if type(mode) is dict else mode
+    )
+
+def pick_representatives(models):
+    """
+    Reduces the given models to the fastest one per coverage class.
+    """
+    fastest = {}
+    for candidate in models:
+        module, model, runtime = candidate
+        key = coverage_class(module, model)
+        if key not in fastest or runtime < fastest[key][2]:
+            fastest[key] = candidate
+    return list(fastest.values())
+
 manifest = tla_utils.load_all_manifests(examples_root)
-small_models = sorted(
-    [
-        (module, model, runtime)
-        for path, spec in manifest
-        for module in spec['modules']
-        for model in module['models']
-            if (runtime := tla_utils.parse_timespan(model['runtime'])) <= timedelta(seconds=30)
-            and model['path'] not in skip_models
-            and not (skip_apalache and model['mode'] == 'symbolic')
-            and (only_models == [] or model['path'] in only_models)
-    ],
-    key = lambda m: m[2],
-    reverse=True
-)
+selected_models = [
+    (module, model, runtime)
+    for path, spec in manifest
+    for module in spec['modules']
+    for model in module['models']
+        if (runtime := tla_utils.parse_timespan(model['runtime'])) <= timedelta(seconds=30)
+        and model['path'] not in skip_models
+        and not (skip_apalache and model['mode'] == 'symbolic')
+        and (only_models == [] or model['path'] in only_models)
+]
+
+if representative_sample:
+    selected_models = pick_representatives(selected_models)
+
+# Ensure longest-running modules go first
+small_models = sorted(selected_models, key = lambda m: m[2], reverse=True)
 
 for path in skip_models:
     logging.info(f'Skipping {path}')
+
+logging.info(f'Checking {len(small_models)} models')
 
 success = all([check_model(*model) for model in small_models])
 exit(0 if success else 1)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -138,11 +138,16 @@ jobs:
           # SKIP=("does/not/exist")
           # strange issue with parsing TLC output
           SKIP=("specifications/ewd840/EWD840.cfg")
-          # Apalache does not yet support Unicode specs:
-          # https://github.com/apalache-mc/apalache/issues/2995
-          APALACHE_FLAG=()
+          UNICODE_FLAGS=()
           if [[ "${{ matrix.unicode }}" == 'true' ]]; then
-            APALACHE_FLAG+=("--skip_apalache")
+            # Apalache does not yet support Unicode specs:
+            # https://github.com/apalache-mc/apalache/issues/2995
+            UNICODE_FLAGS+=("--skip_apalache")
+            # Whether TLC accepts a Unicode module is settled by its lexer, so
+            # every model of a given shape exercises the same code path once
+            # the module has been parsed. One model per shape stands in for the
+            # rest; the ASCII job still checks every model.
+            UNICODE_FLAGS+=("--representative_sample")
           fi
           python $SCRIPT_DIR/check_small_models.py                       \
             --verbose                                                    \
@@ -152,8 +157,11 @@ jobs:
             --community_modules_jar_path $DEPS_DIR/community/modules.jar \
             --examples_root .                                            \
             --skip "${SKIP[@]}"                                          \
-            "${APALACHE_FLAG[@]}"
+            "${UNICODE_FLAGS[@]}"
       - name: Smoke-test large models
+        # Starting TLC on a Unicode module tests the same lexer that parsing
+        # the module already does, so this only runs against ASCII specs.
+        if: (!matrix.unicode)
         run: |
           # SimKnuthYao requires certain number of states to have been generated
           # before termination or else it fails. This makes it not amenable to

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prelude:
+    # None of these checks depend on the platform or on whether specs are
+    # converted to Unicode, so they run once here rather than once per matrix
+    # job. Checking the metadata up front also keeps a malformed manifest from
+    # burning the whole matrix before it fails.
+    runs-on: ubuntu-latest
+    env:
+      SCRIPT_DIR: .github/scripts
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install python packages
+        run: pip install -r "$SCRIPT_DIR/requirements.txt"
+      - name: Check manifest.json format
+        run: |
+          python "$SCRIPT_DIR/check_manifest_schema.py" \
+            --schema_path manifest-schema.json
+      - name: Check manifest files
+        run: |
+          python "$SCRIPT_DIR/check_manifest_files.py"  \
+            --ci_ignore_path .ciignore
+      - name: Check manifest feature flags
+        run: |
+          python "$SCRIPT_DIR/check_manifest_features.py" \
+            --examples_root .
+      - name: Check README spec table
+        run: |
+          python "$SCRIPT_DIR/check_markdown_table.py"  \
+            --readme_path README.md
+
   validate:
+    needs: prelude
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -61,22 +96,6 @@ jobs:
       - name: Download TLA⁺ dependencies (Linux & macOS)
         if: matrix.os != 'windows-latest'
         run: $SCRIPT_DIR/linux-setup.sh $SCRIPT_DIR $DEPS_DIR false
-      - name: Check manifest.json format
-        run: |
-          python "$SCRIPT_DIR/check_manifest_schema.py" \
-            --schema_path manifest-schema.json
-      - name: Check manifest files
-        run: |
-          python "$SCRIPT_DIR/check_manifest_files.py"  \
-            --ci_ignore_path .ciignore
-      - name: Check manifest feature flags
-        run: |
-          python "$SCRIPT_DIR/check_manifest_features.py" \
-            --examples_root .
-      - name: Check README spec table
-        run: |
-          python "$SCRIPT_DIR/check_markdown_table.py"  \
-            --readme_path README.md
       - name: Convert specs to unicode
         if: matrix.unicode
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,11 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         unicode: [true, false]
+        # Unicode support is a matter of file encoding, and Linux and macOS
+        # handle that identically, so the Linux Unicode job covers this one.
+        exclude:
+          - os: macos-latest
+            unicode: true
       fail-fast: false
     env:
       SCRIPT_DIR: .github/scripts

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -15,6 +15,7 @@ Here is a brief overview of each script in the order they are run in [the CI](.g
 1. [`check_markdown_table.py`](.github/scripts/check_markdown_table.py): this uses the [mistletoe](https://pypi.org/project/mistletoe/) markdown parser python package to parse [`README.md`](README.md), extract the spec table, then validate its format & contents against each `manifest.json`; before this script was developed the table tended to diverge wildly from the actual content of this repo.
 1. [`unicode_conversion.py`](.github/scripts/unicode_conversion.py): this script uses [tlauc](https://github.com/tlaplus-community/tlauc) to convert each spec into its Unicode form to ensure TLA⁺ tooling functions identically on ASCII & Unicode specs.
    The CI spawns separate runs with and without conversion of specs to Unicode.
+   The Unicode run converts and parses every module but does not model-check every model, since whether the tools accept a Unicode module is settled when it is parsed.
 1. [`translate_pluscal.py`](.github/scripts/translate_pluscal.py): this script runs the PlusCal translator on all modules containing PlusCal, to ensure their PlusCal syntax is valid.
 1. [`parse_modules.py`](.github/scripts/parse_modules.py): this script runs the SANY parser against all `.tla` files in the repository to ensure they are syntactically & semantically valid.
    This can get quite complicated as many modules import specs defined in Apalache, TLAPM, or the community modules.


### PR DESCRIPTION
We are spending more on GitHub Actions than this repo warrants: a single
push or pull request bills roughly 565 minutes, about $4.50, because the
matrix runs six jobs and the two macOS ones bill at the 10x multiplier.
These three commits remove about 29% of that, some $1.30 per run, without
giving up coverage that we actually rely on.

- **Stop checking Unicode specs on macOS.** Unicode support is a question
  of file encoding, and Linux and macOS handle it identically, so the
  Linux Unicode job already covers it. Windows genuinely differs and is
  untouched. This alone is 120 of the 565 minutes.
- **Check manifest metadata once, before the matrix.** These checks read
  only the manifests and README, so all six jobs computed the same
  answer. Hoisting them into a prerequisite job also means a malformed
  manifest fails in half a minute instead of starting every job first.
- **Model-check a sample of the Unicode specs.** Whether the tools accept
  a Unicode module is settled when it is parsed, and the parse step still
  parses all 421 modules in converted form. So the Unicode jobs now
  model-check one model per shape rather than all 142, and skip the
  large-model smoke test. The ASCII jobs still check all 186 models.

Numbers come from run 32171918535. Full coverage on every platform in
both encodings still runs on `master`.